### PR TITLE
Fix dex-auth on 1.21

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -178,7 +178,10 @@ class Operator(CharmBase):
                         "imageDetails": image_details,
                         "command": ["dex", "serve", "/etc/dex/cfg/config.yaml"],
                         "ports": [{"name": "http", "containerPort": port}],
-                        "envConfig": {"CONFIG_HASH": config_hash.hexdigest()},
+                        "envConfig": {
+                            "CONFIG_HASH": config_hash.hexdigest(),
+                            "KUBERNETES_POD_NAMESPACE": self.model.name,
+                        },
                         "volumeConfig": [
                             {
                                 "name": "config",


### PR DESCRIPTION
Dex is unable to do automatic namespace discovery on kubernetes 1.21 so we help it with this env variable.

Workaround for this mentioned [here](https://github.com/dexidp/dex/issues/2082#issuecomment-818124478).