### PR TITLE
Remove Leader Elected and Fix Ingress Rewrite

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -63,7 +63,6 @@ class Operator(CharmBase):
 
         for event in [
             self.on.install,
-            self.on.leader_elected,
             self.on.upgrade_charm,
             self.on.config_changed,
             self.on.oidc_client_relation_changed,
@@ -77,7 +76,7 @@ class Operator(CharmBase):
             self.interfaces["ingress"].send_data(
                 {
                     "prefix": "/dex",
-                    "rewrite": "/",
+                    "rewrite": "/dex",
                     "service": self.model.app.name,
                     "port": self.model.config["port"],
                 }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -102,7 +102,7 @@ def test_main_ingress(mock_pw, harness):
     relation_data = harness.get_relation_data(rel_id, harness.charm.app.name)
     data = {
         "port": 5556,
-        "rewrite": "/",
+        "rewrite": "/dex",
         "prefix": "/dex",
         "service": "dex-auth",
     }


### PR DESCRIPTION
The leader elected flag causes eternal restarts and isn't actually
needed.

The rewrite field in the ingress relation was wrongly set and cause the
dashboard to never show up.