### PR TITLE
Build Charm through tox with local Schemas

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo snap install charm --classic
-        sudo pip3 install charmcraft
+        sudo snap install charmcraft
         sudo snap install yq
 
     - name: Publish bundle
@@ -27,7 +27,7 @@ jobs:
         set -eux
         echo $CHARMSTORE_CREDENTIAL > ~/.go-cookies
         IMAGE=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)
-        charmcraft build
+        tox -e build
         docker pull $IMAGE
         charm push ./dex-auth.charm \
             cs:~dex-charmers/dex-auth \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 oci-image==1.0.0
 ops==1.1.0
-serialized-data-interface==0.2.0
+serialized-data-interface==0.3.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,6 @@
+pyyaml
+pytest
+bcrypt
+juju
+black
+flake8

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import yaml
 
 import pytest
+import serialized_data_interface.local_sdi as local_sdi
 
 log = logging.getLogger(__name__)
 
@@ -13,6 +14,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test):
     my_charm = await ops_test.build_charm(".")
+    local_sdi.main()
     image_path = METADATA["resources"]["oci-image"]["upstream-source"]
     resources = {"oci-image": image_path}
     await ops_test.model.deploy(my_charm, resources=resources)

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import yaml
 
 import pytest
+import serialized_data_interface.local_sdi as local_sdi
 
 log = logging.getLogger(__name__)
 
@@ -13,6 +14,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test):
     local_charm = await ops_test.build_charm(".")
+    local_sdi.main()
     await ops_test.model.deploy("cs:dex-auth")
     await ops_test.model.wait_for_idle()
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,26 +10,26 @@ envlist = lint,unit,integration
 setenv =
     PYTHONPATH={toxinidir}:{toxinidir}/src
     PYTHONBREAKPOINT=ipdb.set_trace
+deps =
+    -r{toxinidir}/test-requirements.txt
+    -r{toxinidir}/requirements.txt
+allowlist_externals =
+    charmcraft
 
 [testenv:unit]
-deps =
-    pyyaml
-    pytest
-    bcrypt
-    -r{toxinidir}/requirements.txt
 commands = pytest -v --tb native -s {posargs} {toxinidir}/tests/unit
 
 [testenv:integration]
 deps =
-    juju
-    pytest
     pytest-operator
 commands = pytest -v --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 
 [testenv:lint]
-deps =
-    black
-    flake8
 commands =
     flake8 {toxinidir}/tests {toxinidir}/src
     black --check --diff {toxinidir}/tests {toxinidir}/src
+
+[testenv:build]
+commands =
+    charmcraft build
+    python3 -m serialized_data_interface.local_sdi


### PR DESCRIPTION
Adds build step in tox.ini for building the charm and injecting local SDI schemas into the build zip.

Modify GH Actions and integration tests  with new build step