### PR TITLE
fix: missing ServiceAccount token, status handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ jinja2<3.1
 lightkube<=0.9
 ops<1.3.0
 serialized-data-interface<0.4
+tenacity<9

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,14 +94,15 @@ class Operator(CharmBase):
             # Ensure requested resources are up
             try:
                 for attempt in Retrying(
-                        retry=retry_if_exception_type(CheckFailed),
-                        stop=stop_after_delay(max_delay=self._max_time_checking_resources),
-                        wait=wait_exponential(multiplier=0.1, min=0.1, max=15),
-                        reraise=True,
+                    retry=retry_if_exception_type(CheckFailed),
+                    stop=stop_after_delay(max_delay=self._max_time_checking_resources),
+                    wait=wait_exponential(multiplier=0.1, min=0.1, max=15),
+                    reraise=True,
                 ):
                     with attempt:
                         self.logger.info(
-                            f"Checking status of requested resources (attempt {attempt.retry_state.attempt_number})"
+                            f"Checking status of requested resources (attempt "
+                            f"{attempt.retry_state.attempt_number})"
                         )
                         self._check_deployed_resources()
             except CheckFailed:
@@ -241,7 +242,9 @@ class Operator(CharmBase):
                 )
 
         self.logger.info("Checking readiness of found StatefulSets/Deployments")
-        statefulsets_ok, statefulsets_errors = validate_statefulsets_and_deployments(found_resources)
+        statefulsets_ok, statefulsets_errors = validate_statefulsets_and_deployments(
+            found_resources
+        )
         errors.extend(statefulsets_errors)
 
         # Log any errors
@@ -311,6 +314,7 @@ class CheckFailed(Exception):
         self.msg = str(msg)
         self.status_type = status_type
         self.status = status_type(msg)
+
 
 if __name__ == "__main__":
     main(Operator)

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,11 +15,19 @@ from uuid import uuid4
 
 import yaml
 from lightkube import ApiError, Client, codecs
+from lightkube.resources.apps_v1 import StatefulSet, Deployment
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from serialized_data_interface import get_interface
+from tenacity import (
+    Retrying,
+    retry_if_exception_type,
+    stop_after_delay,
+    wait_exponential,
+)
+
 
 try:
     import bcrypt
@@ -49,6 +57,8 @@ class Operator(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
+        self.logger: logging.Logger = logging.getLogger(__name__)
+
         for event in [
             self.on.install,
             self.on.upgrade_charm,
@@ -58,6 +68,8 @@ class Operator(CharmBase):
         ]:
             self.framework.observe(event, self.main)
 
+        self._max_time_checking_resources = 150
+
     @only_leader
     def main(self, event):
         self.model.unit.status = MaintenanceStatus("Calculating manifests")
@@ -66,7 +78,6 @@ class Operator(CharmBase):
         try:
             manifest = self.get_manifest()
         except Exception as err:
-            raise
             self.model.unit.status = BlockedStatus(str(err))
             return
 
@@ -77,10 +88,29 @@ class Operator(CharmBase):
             self.model.unit.status = BlockedStatus(
                 f"There were {len(errors)} errors while applying manifests."
             )
-            log = logging.getLogger(__name__)
             for error in errors:
-                log.error(error)
+                self.logger.error(error)
         else:
+            # Ensure requested resources are up
+            try:
+                for attempt in Retrying(
+                        retry=retry_if_exception_type(CheckFailed),
+                        stop=stop_after_delay(max_delay=self._max_time_checking_resources),
+                        wait=wait_exponential(multiplier=0.1, min=0.1, max=15),
+                        reraise=True,
+                ):
+                    with attempt:
+                        self.logger.info(
+                            f"Checking status of requested resources (attempt {attempt.retry_state.attempt_number})"
+                        )
+                        self._check_deployed_resources()
+            except CheckFailed:
+                self.unit.status = BlockedStatus(
+                    "Some Kubernetes resources did not start correctly during install"
+                )
+                return
+
+            # Otherwise, application is working as expected
             self.model.unit.status = ActiveStatus()
 
     @only_leader
@@ -179,7 +209,55 @@ class Operator(CharmBase):
             for obj in codecs.load_all_yaml(Path(path).read_text(), context=context)
         ]
 
-    def set_manifest(self, manifest):
+    def _check_deployed_resources(self, manifest=None):
+        """Check the status of deployed resources, returning True if ok else raising CheckFailed
+
+        All abnormalities are captured in logs
+
+        Params:
+          manifest: (Optional) list of lightkube objects describing the entire application.  If
+                    omitted, will be computed using self.get_manifest()
+        """
+        if manifest:
+            expected_resources = manifest
+        else:
+            expected_resources = self.get_manifest()
+        found_resources = [None] * len(expected_resources)
+        errors = []
+
+        client = Client()
+
+        self.logger.info("Checking for expected resources")
+        for i, resource in enumerate(expected_resources):
+            try:
+                found_resources[i] = client.get(
+                    type(resource),
+                    resource.metadata.name,
+                    namespace=resource.metadata.namespace,
+                )
+            except ApiError:
+                errors.append(
+                    f"Cannot find k8s object for metadata '{resource.metadata}'"
+                )
+
+        self.logger.info("Checking readiness of found StatefulSets/Deployments")
+        statefulsets_ok, statefulsets_errors = validate_statefulsets_and_deployments(found_resources)
+        errors.extend(statefulsets_errors)
+
+        # Log any errors
+        for err in errors:
+            self.logger.info(err)
+
+        if len(errors) == 0:
+            return True
+        else:
+            raise CheckFailed(
+                "Some Kubernetes resources missing/not ready.  See logs for details",
+                WaitingStatus,
+            )
+
+    @staticmethod
+    def set_manifest(manifest):
         client = Client()
         errors = []
 
@@ -194,12 +272,45 @@ class Operator(CharmBase):
 
         return errors
 
-    def remove_manifest(self, manifest):
+    @staticmethod
+    def remove_manifest(manifest):
         client = Client()
 
         for resource in manifest:
             client.delete(type(resource), resource.metadata.name)
 
+
+def validate_statefulsets_and_deployments(objs):
+    """Determines if all StatefulSets/Deployments have the expected number of readyReplicas
+
+    Returns: Tuple of (Success [Boolean], Errors [list of str error messages]
+    """
+    errors = []
+
+    for obj in objs:
+        if isinstance(obj, (StatefulSet, Deployment)):
+            readyReplicas = obj.status.readyReplicas
+            replicas_expected = obj.spec.replicas
+            if readyReplicas != replicas_expected:
+                message = (
+                    f"StatefulSet {obj.metadata.name} in namespace "
+                    f"{obj.metadata.namespace} has {readyReplicas} readyReplicas, "
+                    f"expected {replicas_expected}"
+                )
+                errors.append(message)
+
+    return len(errors) == 0, errors
+
+
+class CheckFailed(Exception):
+    """Raise this exception if one of the checks in main fails."""
+
+    def __init__(self, msg, status_type=None):
+        super().__init__()
+
+        self.msg = str(msg)
+        self.status_type = status_type
+        self.status = status_type(msg)
 
 if __name__ == "__main__":
     main(Operator)

--- a/src/manifests/config-map.yaml
+++ b/src/manifests/config-map.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ name }}
+  name: {{ name }}-charm
 data:
   config.yaml: |
     {{ config_yaml }}

--- a/src/manifests/deployment.yaml
+++ b/src/manifests/deployment.yaml
@@ -3,19 +3,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ name }}
-  name: {{ name }}
+    app.kubernetes.io/name: {{ name }}-charm
+  name: {{ name }}-charm
 spec:
   replicas: 1
   selector:
     matchLabels:
-        app: {{ name }}
+      app.kubernetes.io/name: {{ name }}-charm
   template:
     metadata:
       labels:
-        app: {{ name }}
+        app.kubernetes.io/name: {{ name }}-charm
     spec:
-      serviceAccountName: {{ name }}
+      serviceAccountName: {{ name }}-charm
       containers:
       - image: quay.io/dexidp/dex:v2.22.0
         name: dex
@@ -34,7 +34,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ name }}
+          name: {{ name }}-charm
           items:
           - key: config.yaml
             path: config.yaml

--- a/src/manifests/roles.yaml
+++ b/src/manifests/roles.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ name }}
+  name: {{ name }}-charm
 rules:
 - apiGroups: ["dex.coreos.com"] # API group created by dex
   resources: ["*"]
@@ -14,18 +14,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ name }}
+  name: {{ name }}-charm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ name }}
+  name: {{ name }}-charm
 subjects:
 - kind: ServiceAccount
-  name: {{ name }}
+  name: {{ name }}-charm
   namespace: {{ namespace }}
 ---
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
-  name: {{ name }}
+  name: {{ name }}-charm
   namespace: {{ namespace }}
+

--- a/src/manifests/service.yaml
+++ b/src/manifests/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ name }}
+  name: {{ name }}-charm
 spec:
   type: ClusterIP
   ports:
@@ -11,4 +11,5 @@ spec:
     protocol: TCP
     targetPort: {{ port }}
   selector:
-    app: {{ name }}
+    app.kubernetes.io/name: {{ name }}-charm
+

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,3 +8,4 @@ flake8-copyright<0.3
 juju<2.10
 pytest<6.3
 pyyaml<6.1
+pytest-mock

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -31,11 +31,15 @@ def ensure_state(self):
     self.state.user_id = "123"
 
 
+@patch("charm.Operator._check_deployed_resources")
 @patch("charm.codecs")
 @patch("charm.Client")
 @patch.object(Operator, "ensure_state", ensure_state)
-def test_main_no_relation(mock_client, mock_codecs, harness):
+def test_main_no_relation(
+    mock_client, mock_codecs, mock_check_deployed_resources, harness
+):
     mock_codecs.load_all_yaml.return_value = [42]
+    mock_check_deployed_resources.return_value = True
 
     harness.set_leader(True)
     harness.begin_with_initial_hooks()
@@ -83,11 +87,13 @@ def test_main_no_relation(mock_client, mock_codecs, harness):
     assert isinstance(harness.charm.model.unit.status, ActiveStatus)
 
 
+@patch("charm.Operator._check_deployed_resources")
 @patch("charm.codecs")
 @patch("charm.Client")
 @patch.object(Operator, "ensure_state", ensure_state)
-def test_main_oidc(mock_client, mock_codecs, harness):
+def test_main_oidc(mock_client, mock_codecs, mock_check_deployed_resources, harness):
     mock_codecs.load_all_yaml.return_value = [42]
+    mock_check_deployed_resources.return_value = True
 
     harness.set_leader(True)
     rel_id = harness.add_relation("oidc-client", "app")
@@ -151,11 +157,13 @@ def test_main_oidc(mock_client, mock_codecs, harness):
     assert isinstance(harness.charm.model.unit.status, ActiveStatus)
 
 
+@patch("charm.Operator._check_deployed_resources")
 @patch("charm.codecs")
 @patch("charm.Client")
 @patch.object(Operator, "ensure_state", ensure_state)
-def test_main_ingress(mock_client, mock_codecs, harness):
+def test_main_ingress(mock_client, mock_codecs, mock_check_deployed_resources, harness):
     mock_codecs.load_all_yaml.return_value = [42]
+    mock_check_deployed_resources.return_value = True
 
     harness.set_leader(True)
     rel_id = harness.add_relation("ingress", "app")


### PR DESCRIPTION
ServiceAccount used for dex-auth was missing a `automountServiceAccountToken: true`, which resulted in the workload pod not having access to the service account and thus the workload going into a crash loop.  This was visible in the pod logs which included `msg="config issuer: /dex" failed to initialize storage: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory`.  This broken pod was not detected by CI because the charm did not check whether deployments/statefulsets actually had their pods up and running.

Fixes committed here:
 * `automountServiceAccountToken: true` added to the ServiceAccount for dex-auth to enable passing a ServiceAccount token to the workload pods
 * some checks during install that attempt to validate that the deployments/statefulsets we deployed are up, raising a BlockedStatus if they're not rather than erroneously going to Active