### PR TITLE
Move send info to main

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,46 +1,30 @@
 name: Publish
-
 on:
   push:
     branches:
+      - master
       - main
       - track/**
-  schedule:
-    - cron: '0 8 * * THU'
-
+  pull_request:
+    branches:
+      - master
+      - main
+      - track/**
 jobs:
-  charm:
+  publish-charm:
     name: Publish Charm
     runs-on: ubuntu-latest
-
+    # Only publish to charmhub if we are pushing to a special branch or running PRs from something named `branch/*`
+    if: (github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))
+    strategy:
+      fail-fast: false
+      matrix:
+        charm-path:
+          - ./
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    - name: Install dependencies
-      run: |
-        set -eux
-        sudo snap install charmcraft --classic --channel=latest/candidate
-        sudo snap install yq
-
-    - name: Charm
-      env:
-        CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-        CHARMCRAFT_DEVELOPER: "y"
-      run: |
-        set -eux
-
-        mkdir -p ~/snap/charmcraft/common/config/
-        echo "$CHARMCRAFT_CREDENTIALS" > ~/snap/charmcraft/common/config/charmcraft.credentials
-
-        NAME=$(yq eval '.name' metadata.yaml)
-        IMAGE=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)
-        REV=$(git rev-parse --abbrev-ref HEAD)
-        TRACK=$([[ "$REV" =~ ^(master|main)$ ]] && echo "latest" || echo "${REV#track/}")
-
-        charmcraft pack --destructive-mode
-        charmcraft upload-resource "$NAME" oci-image --image "$IMAGE"
-        REVISION=$(charmcraft resource-revisions "$NAME" oci-image 2>&1 | awk 'FNR == 2 {print $1}')
-        charmcraft upload ./*.charm \
-            --release=$TRACK/edge \
-            --resource=oci-image:"$REVISION"
+      - uses: actions/checkout@v2
+      - uses: canonical/charmhub-upload-action@0.2.0
+        with:
+          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+          charm-path: ${{ matrix.charm-path }}
+          charmcraft-channel: latest/candidate

--- a/src/charm.py
+++ b/src/charm.py
@@ -64,12 +64,11 @@ class Operator(CharmBase):
             self.on.upgrade_charm,
             self.on.config_changed,
             self.on.oidc_client_relation_changed,
+            self.on.ingress_relation_changed,
         ]:
             self.framework.observe(event, self.main)
 
-        self.framework.observe(self.on["ingress"].relation_changed, self.send_info)
-
-    def send_info(self, event):
+    def send_info(self):
         if self.interfaces["ingress"]:
             self.interfaces["ingress"].send_data(
                 {
@@ -98,6 +97,8 @@ class Operator(CharmBase):
             oidc_client_info = list(oidc_client.get_data().values())
         else:
             oidc_client_info = []
+
+        self.send_info()
 
         # Allows setting a basic username/password combo
         static_username = self.model.config["static-username"]


### PR DESCRIPTION
Ingress information is not send correctly due to events not being triggered correctly. to avoid this we are moving send_info to main to ensure ingress information is always sent.