### PR TITLE
Removed prometheus-app direct relation in test

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,5 +16,5 @@ requires:
 provides:
   metrics-endpoint:
     interface: prometheus_scrape
-  grafana-dashboards:
+  grafana-dashboard:
     interface: grafana_dashboard

--- a/src/charm.py
+++ b/src/charm.py
@@ -76,10 +76,7 @@ class Operator(CharmBase):
             ],
         )
 
-        self.dashboard_provider = GrafanaDashboardProvider(
-            charm=self,
-            relation_name="grafana-dashboard",
-        )
+        self.dashboard_provider = GrafanaDashboardProvider(self)
 
         for event in [
             self.on.install,

--- a/src/charm.py
+++ b/src/charm.py
@@ -78,7 +78,7 @@ class Operator(CharmBase):
 
         self.dashboard_provider = GrafanaDashboardProvider(
             charm=self,
-            relation_name="grafana-dashboards",
+            relation_name="grafana-dashboard",
         )
 
         for event in [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,5 +7,6 @@ flake8<4.1
 flake8-copyright<0.3
 juju<2.10
 pytest<6.3
+pytest-operator<0.17.0
 pyyaml<6.1
 pytest-mock

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -91,7 +91,8 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
         ):
             with attempt:
                 r = requests.get(
-                    f'http://{prometheus_unit_ip}:9090/api/v1/query?query=up{{juju_application="{APP_NAME}"}}'
+                    f'http://{prometheus_unit_ip}:9090/api/v1/query?'
+                    f'query=up{{juju_application="{APP_NAME}"}}'
                 )
                 response = json.loads(r.content.decode("utf-8"))
                 response_status = response["status"]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -62,7 +62,6 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     await ops_test.model.deploy(grafana, channel="latest/beta")
     await ops_test.model.add_relation(prometheus, grafana)
     await ops_test.model.add_relation(APP_NAME, grafana)
-    await ops_test.model.add_relation(prometheus, APP_NAME)
     await ops_test.model.deploy(
         prometheus_scrape_charm,
         channel="latest/beta",


### PR DESCRIPTION
Update of [merged prometheus-grafana integration PR](https://github.com/canonical/dex-auth-operator/pull/47) according to latest Observability Team's review: removed the direct relation between prometheus and dex-auth.