### PR TITLE
Unpinned pytest-operator version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,5 @@ flake8<4.1
 flake8-copyright<0.3
 juju<2.10
 pytest<6.3
-pytest-operator<0.17.0
 pyyaml<6.1
 pytest-mock


### PR DESCRIPTION
Unpinned `pytest-operator<0.17.0` due to recent `pytest-operator` update which fixed the teardown issues.
Note: the dependency is already in `tox` thus removing it from `test-requirements`.