### PR TITLE
Update setuptools and pip version

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,4 +11,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    charm-python-packages: [setuptools, pip]
+    # do not use these versions due to pypa/setuptools_scm#713
+    charm-python-packages: [setuptools!=62.2.0, pip!=22.1]


### PR DESCRIPTION
Use versions other than setuptools 62.2.0 and pip 22.1 due to issue described in pypa/setuptools_scm#713.