### PR TITLE
trust prometheus and grafana in integration tests

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -64,8 +64,8 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     prometheus_scrape_charm = "prometheus-scrape-config-k8s"
     scrape_config = {"scrape_interval": "5s"}
 
-    await ops_test.model.deploy(prometheus, channel="latest/beta")
-    await ops_test.model.deploy(grafana, channel="latest/beta")
+    await ops_test.model.deploy(prometheus, channel="latest/beta", trust=True)
+    await ops_test.model.deploy(grafana, channel="latest/beta", trust=True)
     await ops_test.model.add_relation(prometheus, grafana)
     await ops_test.model.add_relation(APP_NAME, grafana)
     await ops_test.model.deploy(


### PR DESCRIPTION
Fixes #58 

PASSED
------------------------------------------------------------------------------------------- live log teardown -------------------------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:768 Model status:

Model            Controller  Cloud/Region        Version  SLA          Timestamp
test-charm-4485  controller  microk8s/localhost  2.9.31   unsupported  03:12:40Z

App                           Version                Status  Scale  Charm                         Channel     Rev  Address         Exposed  Message
dex-auth                                             active      1  dex-auth                                    0  10.152.183.230  no
grafana-k8s                                          active      1  grafana-k8s                   beta         18  10.152.183.251  no
istio-pilot                   res:oci-image@87fc646  active      1  istio-pilot                   1.5/stable   61  10.152.183.30   no
oidc-gatekeeper               res:oci-image@4e7f8dd  active      1  oidc-gatekeeper               stable       57  10.152.183.83   no
prometheus-k8s                                       active      1  prometheus-k8s                beta         20  10.152.183.173  no
prometheus-scrape-config-k8s                         active      1  prometheus-scrape-config-k8s  beta         18  10.152.183.156  no

Unit                             Workload  Agent  Address      Ports                                   Message
dex-auth/0*                      active    idle   10.1.18.108
grafana-k8s/0*                   active    idle   10.1.18.122
istio-pilot/0*                   active    idle   10.1.18.126  8080/TCP,15010/TCP,15012/TCP,15017/TCP
oidc-gatekeeper/0*               active    idle   10.1.18.118  8080/TCP
prometheus-k8s/0*                active    idle   10.1.18.120
prometheus-scrape-config-k8s/0*  active    idle   10.1.18.84


INFO     pytest_operator.plugin:plugin.py:774 Juju error logs:


INFO     pytest_operator.plugin:plugin.py:861 Resetting model test-charm-4485...