### PR TITLE
CI: Update microk8s from 1.21 to 1.22

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -54,8 +54,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
             provider: microk8s
-            # TODO: Change to 1.22 once https://github.com/juju/python-libjuju/issues/684 is fixed
-            channel: 1.21/stable
+            channel: 1.22/stable
 
       # https://github.com/charmed-kubernetes/actions-operator/issues/27
       - run: sudo snap refresh charmcraft --channel latest/candidate

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-git+https://github.com/juju/python-libjuju.git
+juju
 bcrypt<3.3
 black
 flake8<4.1


### PR DESCRIPTION
This PR updates microk8s version in CI from 1.21 to 1.22.