### PR TITLE
feat: localize SDI schemas

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,12 +7,68 @@ description: |
 requires:
   oidc-client:
     interface: oidc-client
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/oidc-client.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+            redirectURIs:
+              type: array
+              items:
+                type: string
+            secret:
+              type: string
+          required:
+          - id
+          - name
+          - redirectURIs
+          - secret
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/oidc-client.yaml
   ingress:
     interface: ingress
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
+    schema:
+      v2:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            namespace:
+              type: string
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - namespace
+          - prefix
+      v1:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - prefix
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -105,7 +105,7 @@ async def test_relations(ops_test: OpsTest):
         f"{oidc_gatekeeper}:ingress-auth",
     )
 
-    await ops_test.model.deploy("kubeflow-profiles", channel="latest/edge")
+    await ops_test.model.deploy("kubeflow-profiles", channel="latest/edge", trust=True)
     await ops_test.model.deploy("kubeflow-dashboard", channel="latest/edge", trust=True)
     await ops_test.model.add_relation("kubeflow-profiles", "kubeflow-dashboard")
     await ops_test.model.add_relation(f"{istio_pilot}:ingress", "kubeflow-dashboard:ingress")


### PR DESCRIPTION
This vendors all remotely defined serialized-data-interface schemas, embedding them in the respective metadata.yaml(s) rather than storing them as a remote link.  This is to enable offline deployment of the charms, as described in [jira](https://warthogs.atlassian.net/browse/KF-727?atlOrigin=eyJpIjoiN2JjZTdlMGYxNDQ3NDdlYzljZDQxNDQ1MTk0OTdkNTEiLCJwIjoiaiJ9).