### PR TITLE
Add a default `public-url` config value

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ options:
     description: |
       Publicly-accessible endpoint for cluster, or the kubernetes internally-accessible 
       url for dex-auth.  Defaults to its kubernetes internally-accessible url, as 
-      computed by the charm.
+      computed by the charm, if empty (typically, defaults to 'http://dex-auth.kubeflow.svc.cluster.local:5556/dex')
   connectors:
     type: string
     default: ''

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,10 @@ options:
   public-url:
     type: string
     default: ''
-    description: Publicly-accessible endpoint for cluster
+    description: |
+      Publicly-accessible endpoint for cluster, or the kubernetes internally-accessible 
+      url for dex-auth.  Defaults to its kubernetes internally-accessible url, as 
+      computed by the charm.
   connectors:
     type: string
     default: ''


### PR DESCRIPTION
This adds a default `public-url` config value as described in canonical/bundle-kubeflow#608.  After implementing canonical/bundle-kubeflow#608 as a whole, we remove the need for users to modify `public-url`.

While we could deprecate and remove the `public-url` config, it is recommended we leave it as is with this default.  This is because in the medium term we plan on replacing dex+oidc with a different auth setup.  