### PR TITLE
feat: updated get images script

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -43,12 +43,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup operator environment
-        uses: claudiubelu/actions-operator@18ebf92ae3043bd3dd15238e5d9b662d7ba08daf
+        uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
           channel: 1.24/stable
-          # Pinned until this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833
-          bootstrap-options: "--agent-version=2.9.34"
+          juju-channel: 2.9/stable
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 
       # https://github.com/charmed-kubernetes/actions-operator/issues/27

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ inputs.source_branch }}
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.2.2
+        uses: canonical/charming-actions/channel@2.3.0
         id: select-channel
         if: ${{ inputs.destination_channel == '' }}
 
@@ -84,7 +84,7 @@ jobs:
           echo "::set-output name=tag_prefix::$tag_prefix"
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.2
+        uses: canonical/charming-actions/upload-charm@2.3.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,48 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "rebaseWhen": "behind-base-branch",
-    "dependencyDashboard": false,
-    "branchPrefix": "renovate-",
-    "constraints": {
-        "python": "3.8.0"
-    },
-    "pip-compile": {
-        "fileMatch": [
-            "(^|/)requirements\\.in$",
-            "(^|/)requirements-fmt\\.in$",
-            "(^|/)requirements-lint\\.in$",
-            "(^|/)requirements-unit\\.in$",
-            "(^|/)requirements-integration\\.in$",
-            "(^|/)requirements.*\\.in$"
-        ],
-        "lockFileMaintenance": {
-            "enabled": true,
-            "schedule": null
-        }
-    },
-    "pip_requirements": {
-        "enabled": false
-    },
-    "automergeType": "branch",
-    "packageRules": [
-        {
-            "groupName": "testing deps",
-            "matchPackagePatterns": [
-                "^black$",
-                "codespell",
-                "flake8",
-                "flake8-builtins",
-                "flake8-copyright",
-                "flake8-docstrings",
-                "isort",
-                "pep8-naming",
-                "pyproject-flake8",
-                "pytest",
-                "pytest-asyncio",
-                "selenium",
-                "selenium-wire"
-            ],
-            "automerge": true
-        }
+    "extends": [
+        "github>canonical/charmed-kubeflow-workflows"
     ]
 }

--- a/requirements-fmt.txt
+++ b/requirements-fmt.txt
@@ -4,19 +4,21 @@
 #
 #    pip-compile --resolver=backtracking ./requirements-fmt.in
 #
-black==22.12.0
+black==23.3.0
     # via -r ./requirements-fmt.in
 click==8.1.3
     # via black
-isort==5.10.1
+isort==5.12.0
     # via -r ./requirements-fmt.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
-pathspec==0.10.3
+packaging==23.1
     # via black
-platformdirs==2.6.0
+pathspec==0.11.1
+    # via black
+platformdirs==3.5.3
     # via black
 tomli==2.0.1
     # via black
-typing-extensions==4.4.0
+typing-extensions==4.6.3
     # via black

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,6 +1,7 @@
 aiohttp
 jinja2
-juju<3.1
+# Pinning to <3.0 due to compatibility with the 2.9 controller version and 3.0 not being maintained anymore
+juju<3.0
 pytest-operator
 requests
 selenium

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,41 +4,38 @@
 #
 #    pip-compile --resolver=backtracking ./requirements-integration.in
 #
-aiohttp==3.8.3
+aiohttp==3.8.4
     # via -r ./requirements-integration.in
 aiosignal==1.3.1
     # via aiohttp
-anyio==3.6.2
+anyio==3.7.0
     # via
     #   -r ./requirements.txt
     #   httpcore
 asttokens==2.2.1
     # via stack-data
 async-generator==1.10
-    # via
-    #   trio
-    #   trio-websocket
+    # via trio
 async-timeout==4.0.2
     # via aiohttp
-attrs==22.1.0
+attrs==23.1.0
     # via
     #   -r ./requirements.txt
     #   aiohttp
     #   jsonschema
     #   outcome
-    #   pytest
     #   trio
 backcall==0.2.0
     # via ipython
 bcrypt==4.0.1
     # via paramiko
-blinker==1.5
+blinker==1.6.2
     # via selenium-wire
 brotli==1.0.9
     # via selenium-wire
-cachetools==5.2.0
+cachetools==5.3.1
     # via google-auth
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -r ./requirements.txt
     #   httpcore
@@ -51,13 +48,12 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-chardet==3.0.4
+charset-normalizer==3.1.0
     # via
     #   -r ./requirements.txt
+    #   aiohttp
     #   requests
-charset-normalizer==2.1.1
-    # via aiohttp
-cryptography==38.0.4
+cryptography==41.0.1
     # via
     #   paramiko
     #   pyopenssl
@@ -65,17 +61,20 @@ decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-exceptiongroup==1.0.4
+exceptiongroup==1.1.1
     # via
+    #   -r ./requirements.txt
+    #   anyio
     #   pytest
     #   trio
+    #   trio-websocket
 executing==1.2.0
     # via stack-data
 frozenlist==1.3.3
     # via
     #   aiohttp
     #   aiosignal
-google-auth==2.15.0
+google-auth==2.17.3
     # via kubernetes
 h11==0.14.0
     # via
@@ -86,11 +85,11 @@ h2==4.1.0
     # via selenium-wire
 hpack==4.0.0
     # via h2
-httpcore==0.16.2
+httpcore==0.17.2
     # via
     #   -r ./requirements.txt
     #   httpx
-httpx==0.23.1
+httpx==0.24.1
     # via
     #   -r ./requirements.txt
     #   lightkube
@@ -98,19 +97,23 @@ hyperframe==6.0.1
     # via
     #   h2
     #   selenium-wire
-idna==2.10
+idna==3.4
     # via
     #   -r ./requirements.txt
     #   anyio
+    #   httpx
     #   requests
-    #   rfc3986
     #   trio
     #   yarl
-iniconfig==1.1.1
+importlib-resources==5.12.0
+    # via
+    #   -r ./requirements.txt
+    #   jsonschema
+iniconfig==2.0.0
     # via pytest
-ipdb==0.13.9
+ipdb==0.13.13
     # via pytest-operator
-ipython==8.7.0
+ipython==8.12.2
     # via ipdb
 jedi==0.18.2
     # via ipython
@@ -119,11 +122,11 @@ jinja2==3.1.2
     #   -r ./requirements-integration.in
     #   -r ./requirements.txt
     #   pytest-operator
-jsonschema==3.2.0
+jsonschema==4.17.3
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-juju==3.0.4
+juju==2.9.42.4
     # via
     #   -r ./requirements-integration.in
     #   pytest-operator
@@ -131,11 +134,11 @@ jujubundlelib==0.5.7
     # via theblues
 kaitaistruct==0.10
     # via selenium-wire
-kubernetes==17.17.0
+kubernetes==26.1.0
     # via juju
-lightkube==0.11.0
+lightkube==0.13.0
     # via -r ./requirements.txt
-lightkube-models==1.25.4.4
+lightkube-models==1.27.1.4
     # via
     #   -r ./requirements.txt
     #   lightkube
@@ -143,27 +146,27 @@ macaroonbakery==1.3.1
     # via
     #   juju
     #   theblues
-markupsafe==2.1.1
+markupsafe==2.1.3
     # via
     #   -r ./requirements.txt
     #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
-multidict==6.0.3
+multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via typing-inspect
 oauthlib==3.2.2
     # via requests-oauthlib
-ops==1.5.4
+ops==1.5.5
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
 outcome==1.2.0
     # via trio
-packaging==22.0
+packaging==23.1
     # via pytest
 paramiko==2.12.0
     # via juju
@@ -173,9 +176,13 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r ./requirements.txt
+    #   jsonschema
 pluggy==1.0.0
     # via pytest
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.38
     # via ipython
 protobuf==3.20.3
     # via macaroonbakery
@@ -183,17 +190,17 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyasn1==0.4.8
+pyasn1==0.5.0
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
     #   selenium-wire
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
-pygments==2.13.0
+pygments==2.15.1
     # via ipython
 pymacaroons==0.13.0
     # via macaroonbakery
@@ -202,7 +209,7 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyopenssl==22.1.0
+pyopenssl==23.2.0
     # via selenium-wire
 pyparsing==3.0.9
     # via selenium-wire
@@ -210,7 +217,7 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyrsistent==0.19.2
+pyrsistent==0.19.3
     # via
     #   -r ./requirements.txt
     #   jsonschema
@@ -218,19 +225,19 @@ pysocks==1.7.1
     # via
     #   selenium-wire
     #   urllib3
-pytest==7.2.0
+pytest==7.3.2
     # via
     #   pytest-asyncio
     #   pytest-operator
-pytest-asyncio==0.20.3
+pytest-asyncio==0.21.0
     # via pytest-operator
-pytest-operator==0.22.0
+pytest-operator==0.27.0
     # via -r ./requirements-integration.in
 python-dateutil==2.8.2
     # via kubernetes
-pytz==2022.6
+pytz==2023.3
     # via pyrfc3339
-pyyaml==5.4
+pyyaml==6.0
     # via
     #   -r ./requirements.txt
     #   juju
@@ -240,7 +247,7 @@ pyyaml==5.4
     #   ops
     #   pytest-operator
     #   serialized-data-interface
-requests==2.25.0
+requests==2.31.0
     # via
     #   -r ./requirements-integration.in
     #   -r ./requirements.txt
@@ -251,26 +258,20 @@ requests==2.25.0
     #   theblues
 requests-oauthlib==1.3.1
     # via kubernetes
-rfc3986[idna2008]==1.5.0
-    # via
-    #   -r ./requirements.txt
-    #   httpx
 rsa==4.9
     # via google-auth
-selenium==4.7.2
+selenium==4.10.0
     # via
     #   -r ./requirements-integration.in
     #   selenium-wire
 selenium-wire==5.1.0
     # via -r ./requirements-integration.in
-serialized-data-interface==0.3.5
+serialized-data-interface==0.6.0
     # via -r ./requirements.txt
 six==1.16.0
     # via
-    #   -r ./requirements.txt
     #   asttokens
     #   google-auth
-    #   jsonschema
     #   kubernetes
     #   macaroonbakery
     #   paramiko
@@ -287,17 +288,17 @@ sortedcontainers==2.4.0
     # via trio
 stack-data==0.6.2
     # via ipython
-tenacity==8.1.0
+tenacity==8.2.2
     # via -r ./requirements-integration.in
 theblues==0.5.2
     # via juju
-toml==0.10.2
-    # via ipdb
 tomli==2.0.1
-    # via pytest
-toposort==1.7
+    # via
+    #   ipdb
+    #   pytest
+toposort==1.10
     # via juju
-traitlets==5.7.0
+traitlets==5.9.0
     # via
     #   ipython
     #   matplotlib-inline
@@ -305,21 +306,23 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.9.2
+trio-websocket==0.10.3
     # via selenium
-typing-extensions==4.4.0
-    # via typing-inspect
-typing-inspect==0.8.0
+typing-extensions==4.6.3
+    # via
+    #   ipython
+    #   typing-inspect
+typing-inspect==0.9.0
     # via juju
-urllib3[socks]==1.26.13
+urllib3[socks]==2.0.3
     # via
     #   -r ./requirements.txt
     #   kubernetes
     #   requests
     #   selenium
-wcwidth==0.2.5
+wcwidth==0.2.6
     # via prompt-toolkit
-websocket-client==1.4.2
+websocket-client==1.5.3
     # via kubernetes
 websockets==7.0
     # via juju
@@ -327,9 +330,13 @@ wsproto==1.2.0
     # via
     #   selenium-wire
     #   trio-websocket
-yarl==1.8.2
+yarl==1.9.2
     # via aiohttp
-zstandard==0.19.0
+zipp==3.15.0
+    # via
+    #   -r ./requirements.txt
+    #   importlib-resources
+zstandard==0.21.0
     # via selenium-wire
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-lint.in
+++ b/requirements-lint.in
@@ -1,8 +1,6 @@
 codespell
-flake8<6
+flake8
 flake8-builtins
-# Pinned because `flake8-copyright==0.2.3` is incompatible with `flake8>=6`.  Can unpin this
-# when https://github.com/savoirfairelinux/flake8-copyright/pull/20 or a similar fix is released
 flake8-copyright
 pep8-naming
 pyproject-flake8

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,54 +4,58 @@
 #
 #    pip-compile --resolver=backtracking ./requirements-lint.in
 #
-black==22.12.0
+black==23.3.0
     # via -r ./requirements-fmt.txt
 click==8.1.3
     # via
     #   -r ./requirements-fmt.txt
     #   black
-codespell==2.2.2
+codespell==2.2.4
     # via -r ./requirements-lint.in
-flake8==5.0.4
+flake8==6.0.0
     # via
     #   -r ./requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.0.1
+flake8-builtins==2.1.0
     # via -r ./requirements-lint.in
-flake8-copyright==0.2.3
+flake8-copyright==0.2.4
     # via -r ./requirements-lint.in
-isort==5.10.1
+isort==5.12.0
     # via -r ./requirements-fmt.txt
 mccabe==0.7.0
     # via flake8
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via
     #   -r ./requirements-fmt.txt
     #   black
-pathspec==0.10.3
+packaging==23.1
     # via
     #   -r ./requirements-fmt.txt
     #   black
-pep8-naming==0.13.2
+pathspec==0.11.1
+    # via
+    #   -r ./requirements-fmt.txt
+    #   black
+pep8-naming==0.13.3
     # via -r ./requirements-lint.in
-platformdirs==2.6.0
+platformdirs==3.5.3
     # via
     #   -r ./requirements-fmt.txt
     #   black
-pycodestyle==2.9.1
+pycodestyle==2.10.0
     # via flake8
-pyflakes==2.5.0
+pyflakes==3.0.1
     # via flake8
-pyproject-flake8==5.0.4.post1
+pyproject-flake8==6.0.0.post1
     # via -r ./requirements-lint.in
 tomli==2.0.1
     # via
     #   -r ./requirements-fmt.txt
     #   black
     #   pyproject-flake8
-typing-extensions==4.4.0
+typing-extensions==4.6.3
     # via
     #   -r ./requirements-fmt.txt
     #   black

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -4,80 +4,105 @@
 #
 #    pip-compile --resolver=backtracking ./requirements-unit.in
 #
-anyio==3.6.2
+anyio==3.7.0
     # via
     #   -r ./requirements.txt
     #   httpcore
-attrs==22.1.0
+attrs==23.1.0
     # via
     #   -r ./requirements.txt
     #   jsonschema
-    #   pytest
 bcrypt==4.0.1
     # via -r ./requirements-unit.in
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -r ./requirements.txt
     #   httpcore
     #   httpx
     #   requests
-chardet==3.0.4
+charmed-kubeflow-chisme==0.0.11
+    # via -r ./requirements.txt
+charset-normalizer==3.1.0
     # via
     #   -r ./requirements.txt
     #   requests
-coverage==6.5.0
+coverage==7.2.7
     # via -r ./requirements-unit.in
-exceptiongroup==1.0.4
-    # via pytest
+deepdiff==6.2.1
+    # via
+    #   -r ./requirements.txt
+    #   charmed-kubeflow-chisme
+exceptiongroup==1.1.1
+    # via
+    #   -r ./requirements.txt
+    #   anyio
+    #   pytest
 h11==0.14.0
     # via
     #   -r ./requirements.txt
     #   httpcore
-httpcore==0.16.2
+httpcore==0.17.2
     # via
     #   -r ./requirements.txt
     #   httpx
-httpx==0.23.1
+httpx==0.24.1
     # via
     #   -r ./requirements.txt
     #   lightkube
-idna==2.10
+idna==3.4
     # via
     #   -r ./requirements.txt
     #   anyio
+    #   httpx
     #   requests
-    #   rfc3986
-iniconfig==1.1.1
-    # via pytest
-jinja2==3.1.2
-    # via -r ./requirements.txt
-jsonschema==3.2.0
-    # via
-    #   -r ./requirements.txt
-    #   serialized-data-interface
-lightkube==0.11.0
-    # via -r ./requirements.txt
-lightkube-models==1.25.4.4
-    # via
-    #   -r ./requirements.txt
-    #   lightkube
-markupsafe==2.1.1
-    # via
-    #   -r ./requirements.txt
-    #   jinja2
-ops==1.5.4
-    # via
-    #   -r ./requirements.txt
-    #   serialized-data-interface
-packaging==22.0
-    # via pytest
-pluggy==1.0.0
-    # via pytest
-pyrsistent==0.19.2
+importlib-resources==5.12.0
     # via
     #   -r ./requirements.txt
     #   jsonschema
-pytest==7.2.0
+iniconfig==2.0.0
+    # via pytest
+jinja2==3.1.2
+    # via
+    #   -r ./requirements.txt
+    #   charmed-kubeflow-chisme
+jsonschema==4.17.3
+    # via
+    #   -r ./requirements.txt
+    #   serialized-data-interface
+lightkube==0.13.0
+    # via
+    #   -r ./requirements.txt
+    #   charmed-kubeflow-chisme
+lightkube-models==1.27.1.4
+    # via
+    #   -r ./requirements.txt
+    #   lightkube
+markupsafe==2.1.3
+    # via
+    #   -r ./requirements.txt
+    #   jinja2
+ops==1.5.5
+    # via
+    #   -r ./requirements.txt
+    #   charmed-kubeflow-chisme
+    #   serialized-data-interface
+ordered-set==4.1.0
+    # via
+    #   -r ./requirements.txt
+    #   deepdiff
+packaging==23.1
+    # via pytest
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r ./requirements.txt
+    #   jsonschema
+pluggy==1.0.0
+    # via pytest
+pyrsistent==0.19.3
+    # via
+    #   -r ./requirements.txt
+    #   jsonschema
+pytest==7.3.2
     # via
     #   -r ./requirements-unit.in
     #   pytest-lazy-fixture
@@ -86,38 +111,43 @@ pytest-lazy-fixture==0.6.3
     # via -r ./requirements-unit.in
 pytest-mock==3.10.0
     # via -r ./requirements-unit.in
-pyyaml==5.4
+pyyaml==6.0
     # via
     #   -r ./requirements.txt
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.25.0
+requests==2.31.0
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-rfc3986[idna2008]==1.5.0
+ruamel-yaml==0.17.31
     # via
     #   -r ./requirements.txt
-    #   httpx
-serialized-data-interface==0.3.5
+    #   charmed-kubeflow-chisme
+ruamel-yaml-clib==0.2.7
+    # via
+    #   -r ./requirements.txt
+    #   ruamel-yaml
+serialized-data-interface==0.6.0
     # via -r ./requirements.txt
-six==1.16.0
-    # via
-    #   -r ./requirements.txt
-    #   jsonschema
 sniffio==1.3.0
     # via
     #   -r ./requirements.txt
     #   anyio
     #   httpcore
     #   httpx
+tenacity==8.2.2
+    # via
+    #   -r ./requirements.txt
+    #   charmed-kubeflow-chisme
 tomli==2.0.1
     # via pytest
-urllib3==1.26.13
+urllib3==2.0.3
     # via
     #   -r ./requirements.txt
     #   requests
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+zipp==3.15.0
+    # via
+    #   -r ./requirements.txt
+    #   importlib-resources

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 jinja2
-ops
+ops<2
 lightkube
-serialized-data-interface<0.4
+serialized-data-interface
+charmed-kubeflow-chisme

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,64 +4,82 @@
 #
 #    pip-compile --resolver=backtracking ./requirements.in
 #
-anyio==3.6.2
+anyio==3.7.0
     # via httpcore
-attrs==22.1.0
+attrs==23.1.0
     # via jsonschema
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   httpcore
     #   httpx
     #   requests
-chardet==3.0.4
+charmed-kubeflow-chisme==0.0.11
+    # via -r ./requirements.in
+charset-normalizer==3.1.0
     # via requests
+deepdiff==6.2.1
+    # via charmed-kubeflow-chisme
+exceptiongroup==1.1.1
+    # via anyio
 h11==0.14.0
     # via httpcore
-httpcore==0.16.2
+httpcore==0.17.2
     # via httpx
-httpx==0.23.1
+httpx==0.24.1
     # via lightkube
-idna==2.10
+idna==3.4
     # via
     #   anyio
+    #   httpx
     #   requests
-    #   rfc3986
+importlib-resources==5.12.0
+    # via jsonschema
 jinja2==3.1.2
-    # via -r ./requirements.in
-jsonschema==3.2.0
-    # via serialized-data-interface
-lightkube==0.11.0
-    # via -r ./requirements.in
-lightkube-models==1.25.4.4
-    # via lightkube
-markupsafe==2.1.1
-    # via jinja2
-ops==1.5.4
     # via
     #   -r ./requirements.in
+    #   charmed-kubeflow-chisme
+jsonschema==4.17.3
+    # via serialized-data-interface
+lightkube==0.13.0
+    # via
+    #   -r ./requirements.in
+    #   charmed-kubeflow-chisme
+lightkube-models==1.27.1.4
+    # via lightkube
+markupsafe==2.1.3
+    # via jinja2
+ops==1.5.5
+    # via
+    #   -r ./requirements.in
+    #   charmed-kubeflow-chisme
     #   serialized-data-interface
-pyrsistent==0.19.2
+ordered-set==4.1.0
+    # via deepdiff
+pkgutil-resolve-name==1.3.10
     # via jsonschema
-pyyaml==5.4
+pyrsistent==0.19.3
+    # via jsonschema
+pyyaml==6.0
     # via
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.25.0
+requests==2.31.0
     # via serialized-data-interface
-rfc3986[idna2008]==1.5.0
-    # via httpx
-serialized-data-interface==0.3.5
+ruamel-yaml==0.17.31
+    # via charmed-kubeflow-chisme
+ruamel-yaml-clib==0.2.7
+    # via ruamel-yaml
+serialized-data-interface==0.6.0
     # via -r ./requirements.in
-six==1.16.0
-    # via jsonschema
 sniffio==1.3.0
     # via
     #   anyio
     #   httpcore
     #   httpx
-urllib3==1.26.13
+tenacity==8.2.2
+    # via charmed-kubeflow-chisme
+urllib3==2.0.3
     # via requests
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+zipp==3.15.0
+    # via importlib-resources

--- a/src/prometheus_alert_rules/unit_unavailable.rule
+++ b/src/prometheus_alert_rules/unit_unavailable.rule
@@ -1,6 +1,6 @@
 alert: DexAuthUnitIsUnavailable
 expr: up < 1
-for: 0m
+for: 5m
 labels:
   severity: critical
 annotations:

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -2,13 +2,8 @@
 #
 # This script returns list of container images that are managed by this charm and/or its workload
 #
-# static list
-STATIC_IMAGE_LIST=(
-)
 # dynamic list
-git checkout origin/track/2.31
 IMAGE_LIST=()
 IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
-
-printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
 printf "%s\n" "${IMAGE_LIST[@]}"
+

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,6 @@ allowlist_externals =
     xargs
 commands = 
 ; uses 'bash -c' because piping didn't work in regular tox commands
-  pip-compile requirements.in
-  pip-compile requirements-fmt.in
   bash -c 'find . -type f -name "requirements*.in" | xargs --replace=\{\} pip-compile --resolver=backtracking \{\}'
 deps =
     pip-tools
@@ -53,7 +51,7 @@ commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
     codespell {toxinidir}/. --skip {toxinidir}/./.git --skip {toxinidir}/./.tox \
-      --skip {toxinidir}/./build --skip {toxinidir}/./lib --skip {toxinidir}/./venv \
+      --skip {toxinidir}/./build --skip {toxinidir}/./lib --skip {toxinidir}/./venv* \
       --skip {toxinidir}/./.mypy_cache \
       --skip {toxinidir}/./icon.svg --skip *.json.tmpl
     # pflake8 wrapper supports config from pyproject.toml


### PR DESCRIPTION
Repository specific list of images.
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup. Script is specific for track/2.31 branch to capture all images for that branch. Branch is handled in kubeflow-ci and bundle automation using bundle file.

Summary of changes:
- Re-designed get images script to retrieve all images for current branch. Branch management is done outside of this script.