### PR TITLE
feat: Remove apt-install from Dex Charm

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -3,11 +3,11 @@
 # See LICENSE file for licensing details.
 
 import logging
-import subprocess
 from random import choices
 from string import ascii_letters
 from uuid import uuid4
 
+import bcrypt
 import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
@@ -19,13 +19,6 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import Layer
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interface
-
-try:
-    import bcrypt
-except ImportError:
-    subprocess.check_call(["apt", "update"])
-    subprocess.check_call(["apt", "install", "-y", "python3-bcrypt"])
-    import bcrypt
 
 METRICS_PATH = "/metrics"
 METRICS_PORT = "5558"


### PR DESCRIPTION
Currently, Dex Charm is doing apt install. Update this logic to ensure the Dex Charm can work in an air-gapped environment

Closes https://github.com/canonical/dex-auth-operator/issues/100