### PR TITLE
requirements: Pin selenium version to 4.10.x

### DIFF
--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -6,6 +6,7 @@ lightkube
 pytest-operator
 pyyaml
 requests
-selenium
+# Pinning to <4.11 because upgrading to 4.11.2 results in chrome version compatibility issue. See https://github.com/canonical/dex-auth-operator/issues/151.
+selenium<4.11
 selenium-wire
 tenacity


### PR DESCRIPTION
Pin Selenium version to `<4.11` in charm's integration tests because upgrading to `4.11.2` results in the following issue https://github.com/canonical/dex-auth-operator/issues/151. 

Related runs 
https://github.com/canonical/dex-auth-operator/actions/runs/5763096636/job/15669866245?pr=132#step:5:2253
https://github.com/canonical/dex-auth-operator/actions/runs/5763096636/job/15627005664?pr=132#step:5:2066