### PR TITLE
refactor: generate dex-auth configuration outside of update_layer()

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,9 +3,11 @@
 
 from unittest.mock import patch
 
+import ops
 import pytest
 import yaml
-from ops.model import ActiveStatus, WaitingStatus
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import Operator
@@ -52,6 +54,91 @@ def test_install_event(update, harness):
     assert harness.get_container_pebble_plan("dex")._services is not None
 
     assert isinstance(harness.charm.model.unit.status, ActiveStatus)
+
+@patch("charm.KubernetesServicePatch", lambda x, y: None)
+def test_generate_dex_auth_config_raises(harness):
+    """Check the method raises when static login is disabled and no connectors are provided."""
+    harness.begin()
+    config_updates = {
+        "enable-password-db": False,
+        "port": 5555,
+        "public-url": "dummy.url",
+    }
+
+    harness.update_config(config_updates)
+
+    with pytest.raises(ErrorWithStatus) as error:
+        harness.charm._generate_dex_auth_config()
+    assert (
+        error.value.msg
+        == "Please add a connectors configuration to proceed without a static login."
+    )
+    assert error.value.status_type == BlockedStatus
+
+
+@pytest.mark.parametrize(
+    "dex_config",
+    (
+        {
+            "enable-password-db": False,
+            "port": 5555,
+            "public-url": "dummy.url",
+            "connectors": "test-connector",
+        },
+        {
+            "enable-password-db": True,
+            "port": 5555,
+            "public-url": "dummy.url",
+            "static-username": "new-user",
+            "static-password": "new-pass",
+        },
+    ),
+)
+@patch("charm.Operator._update_layer")
+@patch.object(Operator, "ensure_state", ensure_state)
+@patch("charm.KubernetesServicePatch", lambda x, y: None)
+def test_generate_dex_auth_config_returns(update_layer, dex_config, harness):
+    """Check the method returns dex-auth configuration when different settings are provided."""
+    harness.set_leader(True)
+    harness.begin()
+    harness.set_can_connect("dex", True)
+
+    harness.update_config(dex_config)
+
+    test_configuration = harness.charm._generate_dex_auth_config()
+    assert test_configuration is not None
+
+    test_configuration_dict = yaml.safe_load(test_configuration)
+    assert (
+        yaml.safe_load(harness.model.config["connectors"]) == test_configuration_dict["connectors"]
+    )
+    assert (
+        harness.model.config["enable-password-db"] == test_configuration_dict["enablePasswordDB"]
+    )
+
+    static_passwords = test_configuration_dict.get("staticPasswords")
+    assert isinstance(static_passwords, list)
+    if not harness.model.config["static-username"]:
+        assert len(static_passwords) == 0
+    else:
+        assert len(static_passwords) == 1
+        assert harness.model.config["static-username"] == static_passwords[0].get("username")
+
+
+@patch("charm.KubernetesServicePatch", lambda x, y: None)
+def test_disable_static_login_no_connector_blocked_status(harness):
+    harness.set_leader(True)
+    harness.begin()
+    harness.set_can_connect("dex", True)
+
+    config_updates = {
+        "enable-password-db": False,
+        "port": 5555,
+        "public-url": "dummy.url",
+    }
+
+    harness.update_config(config_updates)
+    assert isinstance(harness.charm.model.unit.status, BlockedStatus)
 
 
 @patch("charm.KubernetesServicePatch", lambda x, y: None)


### PR DESCRIPTION
Generate dex-auth configuration outside of update_layer() will allow us to have error handling when checking for certain conditions of the configurations without cluttering too much the update_layer() method.

This commit also adds unit tests for the helper method that's used for generating the aforementioned configuration.