### PR TITLE
feat: make charm work on airgap environments

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,3 +12,6 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
+    # Install rustc and cargo as build packages because some charm's
+    # dependencies need this to be built and installed from source.
+    build-packages: [rustc, cargo]

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-
+bcrypt
 jinja2
 # pin to <2 due to track/2.31 depends on <2
 ops<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ anyio==3.7.1
     # via httpcore
 attrs==23.1.0
     # via jsonschema
+bcrypt==4.0.1
+    # via -r ./requirements.in
 certifi==2023.7.22
     # via
     #   httpcore

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,11 +3,11 @@
 # See LICENSE file for licensing details.
 
 import logging
-import subprocess
 from random import choices
 from string import ascii_letters
 from uuid import uuid4
 
+import bcrypt
 import yaml
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
@@ -18,14 +18,6 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import Layer
 from serialized_data_interface import NoVersionsListed, get_interface
-
-try:
-    import bcrypt
-except ImportError:
-    subprocess.check_call(["apt", "update"])
-    subprocess.check_call(["apt", "install", "-y", "python3-bcrypt"])
-    import bcrypt
-
 
 METRICS_PATH = "/metrics"
 METRICS_PORT = "5558"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -186,8 +186,29 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     prometheus_scrape_charm = "prometheus-scrape-config-k8s"
     scrape_config = {"scrape_interval": "5s"}
 
-    await ops_test.model.deploy(prometheus, channel="latest/beta", trust=True)
-    await ops_test.model.deploy(grafana, channel="latest/beta", trust=True)
+    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/688 is closed
+    await ops_test.juju(
+        "deploy",
+        prometheus,
+        "--channel",
+        "latest/edge",
+        "--revision",
+        "137",
+        "--trust",
+        check=True,
+    )
+    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/690 is closed
+    await ops_test.juju(
+        "deploy",
+        grafana,
+        "--channel",
+        "latest/edge",
+        "--revision",
+        "89",
+        "--trust",
+        check=True,
+    )
+
     await ops_test.model.add_relation(
         f"{prometheus}:grafana-dashboard", f"{grafana}:grafana-dashboard"
     )


### PR DESCRIPTION
This PR cherry picks 4e42ce3853135ee8fdf2829f10553442c2c86bf6, partially cherry-picks a716963, and makes changes to the requirements.* files so that dex-auth can be deployed in an airgap environment. These changes are mirroring in `track/2.31` what we currently have in `main`.

Fixes #167 