### PR TITLE
Update dex image to pull from Canonical-built source

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -85,4 +85,4 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for dex container
-    upstream-source: dexidp/dex:v2.36.0
+    upstream-source: charmedkubeflow/dex:2.36.0-f262d95

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -97,7 +97,8 @@ async def test_relations(ops_test: OpsTest):
         timeout=90 * 10,
     )
 
-    await ops_test.model.deploy(oidc_gatekeeper, channel="latest/edge", config=OIDC_CONFIG)
+    # DEBUG: temporarily set channel to a ephemeral branch for testing
+    await ops_test.model.deploy(oidc_gatekeeper, channel="latest/edge/pr-128", config=OIDC_CONFIG)
     await ops_test.model.add_relation(oidc_gatekeeper, APP_NAME)
     await ops_test.model.add_relation(f"{istio_pilot}:ingress", f"{APP_NAME}:ingress")
     await ops_test.model.add_relation(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -97,8 +97,7 @@ async def test_relations(ops_test: OpsTest):
         timeout=90 * 10,
     )
 
-    # DEBUG: temporarily set channel to a ephemeral branch for testing
-    await ops_test.model.deploy(oidc_gatekeeper, channel="latest/edge/pr-128", config=OIDC_CONFIG)
+    await ops_test.model.deploy(oidc_gatekeeper, channel="latest/edge", config=OIDC_CONFIG)
     await ops_test.model.add_relation(oidc_gatekeeper, APP_NAME)
     await ops_test.model.add_relation(f"{istio_pilot}:ingress", f"{APP_NAME}:ingress")
     await ops_test.model.add_relation(


### PR DESCRIPTION
Updates the dex image to use `charmedkubeflow/dex:2.36.0-f262d95`, which is built from [dex-auth-rocks](https://github.com/canonical/dex-auth-rocks)