### PR TITLE
Update `track/2.36` dex image to pull from Canonical-built source

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -85,4 +85,4 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for dex container
-    upstream-source: dexidp/dex:v2.36.0
+    upstream-source: charmedkubeflow/dex:2.36.0-f262d95


### PR DESCRIPTION
Updates the dex image to use `charmedkubeflow/dex:2.36.0-f262d95`, which is built from [dex-auth-rocks](https://github.com/canonical/dex-auth-rocks)