### PR TITLE
Change image to v2.39.1

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -85,4 +85,4 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for dex container
-    upstream-source: charmedkubeflow/dex:2.36.0-f262d95
+    upstream-source: ghcr.io/dexidp/dex:v2.39.1


### PR DESCRIPTION
closes: https://github.com/canonical/dex-auth-operator/issues/192

Using the upstream `v2.39.1` image.