### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.29-strict/stable
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 
       # https://github.com/charmed-kubernetes/actions-operator/issues/27


### PR DESCRIPTION
Part of [canonical/bundle-kubeflow/#944](https://github.com/canonical/bundle-kubeflow/issues/944)