### PR TITLE
feat: add dex_oidc_config library

### DIFF
--- a/lib/charms/dex_auth/v0/dex_oidc_config.py
+++ b/lib/charms/dex_auth/v0/dex_oidc_config.py
@@ -69,6 +69,7 @@ class ProviderCharm(CharmBase):
         ...
         self._dex_oidc_config_provider = DexOidcConfigProvider(self)
         self.observe(self.on.some_event, self._some_event_handler)
+
     def _some_event_handler(self, ...):
         # This will update the relation data bag with the issuer URL 
         try:
@@ -171,7 +172,7 @@ class DexOidcConfigRequirer(Object):
 
     Args:
         charm (CharmBase): the provider application
-        refresh_event: (list, optional): list of BoundEvents that this manager should handle.
+        refresh_events: (list, optional): list of BoundEvents that this manager should handle.
                        Use this to update the data sent on this relation on demand.
         relation_name (str, optional): the name of the relation
 
@@ -185,7 +186,7 @@ class DexOidcConfigRequirer(Object):
     def __init__(
         self,
         charm: CharmBase,
-        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+        refresh_events: Optional[List[BoundEvent]] = None,
         relation_name: Optional[str] = DEFAULT_RELATION_NAME,
     ):
         super().__init__(charm, relation_name)
@@ -201,10 +202,8 @@ class DexOidcConfigRequirer(Object):
             self._charm.on[self._relation_name].relation_broken, self._on_relation_broken
         )
 
-        if refresh_event:
-            if not isinstance(refresh_event, (tuple, list)):
-                refresh_event = [refresh_event]
-            for evt in refresh_event:
+        if refresh_events:
+            for evt in refresh_events:
                 self.framework.observe(evt, self._on_relation_changed)
 
     def get_data(self) -> DexOidcConfigObject:
@@ -289,7 +288,7 @@ class DexOidcConfigProvider(Object):
     Args:
         charm (CharmBase): the provider application
         issuer_url (str): This is the canonical URL that OIDC clients MUST use to refer to dex.
-        refresh_event: (list, optional): list of BoundEvents that this manager should handle.  Use this to update
+        refresh_events: (list, optional): list of BoundEvents that this manager should handle.  Use this to update
                        the data sent on this relation on demand.
         relation_name (str, optional): the name of the relation
 
@@ -302,7 +301,7 @@ class DexOidcConfigProvider(Object):
         self,
         charm: CharmBase,
         issuer_url: str,
-        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+        refresh_events: Optional[List[BoundEvent]] = None,
         relation_name: Optional[str] = DEFAULT_RELATION_NAME,
     ):
         super().__init__(charm, relation_name)
@@ -315,10 +314,8 @@ class DexOidcConfigProvider(Object):
 
         self.framework.observe(self.charm.on[self.relation_name].relation_created, self._send_data)
 
-        if refresh_event:
-            if not isinstance(refresh_event, (tuple, list)):
-                refresh_event = [refresh_event]
-            for evt in refresh_event:
+        if refresh_events:
+            for evt in refresh_events:
                 self.framework.observe(evt, self._send_data)
 
     def _send_data(self, _) -> None:
@@ -360,6 +357,8 @@ class DexOidcConfigProviderWrapper(Object):
                 "DexOidcConfigProvider handled send_data event when it is not the leader."
                 "Skipping event - no data sent."
             )
+            return
+
         # Update the relation data bag with Dex's OIDC configuration
         relations = self.charm.model.relations[self.relation_name]
 

--- a/lib/charms/dex_auth/v0/dex_oidc_config.py
+++ b/lib/charms/dex_auth/v0/dex_oidc_config.py
@@ -150,7 +150,7 @@ class DexOidcConfigUpdatedEvent(RelationEvent):
 class DexOidcConfigEvents(ObjectEvents):
     """Events for the Dex OIDC config library."""
 
-    updated = EventSource(DexOidcConfigUpdatedEventDex OIDC config)
+    updated = EventSource(DexOidcConfigUpdatedEvent)
 
 
 class DexOidcConfigObject(BaseModel):

--- a/lib/charms/dex_auth/v0/dex_oidc_config.py
+++ b/lib/charms/dex_auth/v0/dex_oidc_config.py
@@ -239,7 +239,9 @@ class DexOidcConfigRequirerWrapper(Object):
         """Series of checks for the relation and relation data.
 
         Args:
-            relation (Relation): the relation object to run the checks on
+            relation (Relation): the relation object to run the checks on.
+              This object must always come from a call of get_relation, which
+              can either return the Relation object or None.
 
         Raises:
             DexOidcConfigRelationDataMissingError if data is missing or incomplete

--- a/lib/charms/dex_auth/v0/dex_oidc_config.py
+++ b/lib/charms/dex_auth/v0/dex_oidc_config.py
@@ -235,13 +235,13 @@ class DexOidcConfigRequirerWrapper(Object):
         self.relation_name = relation_name
 
     @staticmethod
-    def _validate_relation(relation: Relation) -> None:
+    def _validate_relation(relation: Optional[Relation]) -> None:
         """Series of checks for the relation and relation data.
 
         Args:
-            relation (Relation): the relation object to run the checks on.
+            relation (optional, Relation): the relation object to run the checks on.
               This object must always come from a call of get_relation, which
-              can either return the Relation object or None.
+              can either return a Relation object or None.
 
         Raises:
             DexOidcConfigRelationDataMissingError if data is missing or incomplete

--- a/lib/charms/dex_auth/v0/dex_oidc_config.py
+++ b/lib/charms/dex_auth/v0/dex_oidc_config.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for sharing Dex's OIDC configuration with OIDC clients.
+
+TODO
+"""
+import logging
+from typing import List, Optional, Union
+
+from ops.charm import CharmBase, RelationEvent
+from ops.framework import BoundEvent, EventSource, Object, ObjectEvents
+from ops.model import Relation
+from pydantic import BaseModel
+
+# The unique Charmhub library identifier, never change it
+LIBID = "eb5a471989b246e4977399bc8cf9ae6f"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+# Default relation and interface names. If changed, consistency must be kept
+# across the provider and requirer.
+DEFAULT_RELATION_NAME = "dex-oidc-config"
+DEFAULT_INTERFACE_NAME = "dex-oidc-config"
+REQUIRED_ATTRIBUTES = ["issuer-url"]
+
+logger = logging.getLogger(__name__)
+
+
+class DexOidcConfigRelationError(Exception):
+    """Base exception class for any relation error handled by this library."""
+
+    pass
+
+
+class DexOidcConfigRelationMissingError(DexOidcConfigRelationError):
+    """Exception to raise when the relation is missing on either end."""
+
+    def __init__(self):
+        self.message = "Missing relation with a k8s service info provider."
+        super().__init__(self.message)
+
+
+class DexOidcConfigRelationDataMissingError(DexOidcConfigRelationError):
+    """Exception to raise when there is missing data in the relation data bag."""
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+class DexOidcConfigUpdatedEvent(RelationEvent):
+    """Indicates the Dex OIDC config data was updated."""
+
+
+class DexOidcConfigEvents(ObjectEvents):
+    """Events for the Dex OIDC config library."""
+
+    updated = EventSource(DexOidcConfigUpdatedEvent)
+
+
+class DexOidcConfigObject(BaseModel):
+    """Representation of a Dex OIDC config object.
+
+    Args:
+        issuer_url: This is the canonical URL that OIDC clients MUST use to refer to dex.
+    """
+
+    issuer_url: str
+
+
+class DexOidcConfigRequirer(Object):
+    """Implement the Requirer end of the Dex OIDC config relation.
+
+    This library emits:
+    * DexOidcConfigUpdatedEvent: when data received on the relation is updated.
+
+    Args:
+        charm (CharmBase): the provider application
+        refresh_event: (list, optional): list of BoundEvents that this manager should handle.
+                       Use this to update the data sent on this relation on demand.
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the requirer application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    on = DexOidcConfigEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+        relation_name: Optional[str] = DEFAULT_RELATION_NAME,
+    ):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._requirer_wrapper = DexOidcConfigRequirerWrapper(self._charm, self._relation_name)
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_changed, self._on_relation_changed
+        )
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_broken, self._on_relation_broken
+        )
+
+        if refresh_event:
+            if not isinstance(refresh_event, (tuple, list)):
+                refresh_event = [refresh_event]
+            for evt in refresh_event:
+                self.framework.observe(evt, self._on_relation_changed)
+
+    def get_data(self) -> DexOidcConfigObject:
+        """Return a DexOidcConfigObject."""
+        return self._requirer_wrapper.get_data()
+
+    def _on_relation_changed(self, event: BoundEvent) -> None:
+        """Handle relation-changed event for this relation."""
+        self.on.updated.emit(event.relation)
+
+    def _on_relation_broken(self, event: BoundEvent) -> None:
+        """Handle relation-broken event for this relation."""
+        self.on.updated.emit(event.relation)
+
+
+class DexOidcConfigRequirerWrapper(Object):
+    """Wrapper for the relation data getting logic.
+
+    Args:
+        charm (CharmBase): the requirer application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, charm, relation_name: Optional[str] = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+
+    @staticmethod
+    def _validate_relation(relation: Relation) -> None:
+        """Series of checks for the relation and relation data.
+
+        Args:
+            relation (Relation): the relation object to run the checks on
+
+        Raises:
+            DexOidcConfigRelationDataMissingError if data is missing or incomplete
+            DexOidcConfigRelationMissingError: if there is no related application
+        """
+        # Raise if there is no related application
+        if not relation:
+            raise DexOidcConfigRelationMissingError()
+
+        # Extract remote app information from relation
+        remote_app = relation.app
+        # Get relation data from remote app
+        relation_data = relation.data[remote_app]
+
+        # Raise if there is no data found in the relation data bag
+        if not relation_data:
+            raise DexOidcConfigRelationDataMissingError(
+                f"No data found in relation {relation.name} data bag."
+            )
+
+    def get_data(self) -> DexOidcConfigObject:
+        """Return a DexOidcConfigObject containing Dex's OIDC configuration.
+
+        Raises:
+            DexOidcConfigRelationDataMissingError: if data is missing entirely or some attributes
+            DexOidcConfigRelationMissingError: if there is no related application
+            ops.model.TooManyRelatedAppsError: if there is more than one related application
+        """
+        # Validate relation data
+        # Raises TooManyRelatedAppsError if related to more than one app
+        relation = self.model.get_relation(self.relation_name)
+
+        self._validate_relation(relation=relation)
+
+        # Get relation data from remote app
+        relation_data = relation.data[relation.app]
+
+        return DexOidcConfigObject(issuer_url=relation_data["issuer-url"])
+
+
+class DexOidcConfigProvider(Object):
+    """Implement the Provider end of the Dex OIDC config relation.
+
+    Observes relation events to send data to related applications.
+
+    Args:
+        charm (CharmBase): the provider application
+        issuer_url (str): This is the canonical URL that OIDC clients MUST use to refer to dex.
+        refresh_event: (list, optional): list of BoundEvents that this manager should handle.  Use this to update
+                       the data sent on this relation on demand.
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the provider application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        issuer_url: str,
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+        relation_name: Optional[str] = DEFAULT_RELATION_NAME,
+    ):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self._provider_wrapper = DexOidcConfigProviderWrapper(self.charm, self.relation_name)
+        self._issuer_url = issuer_url
+
+        self.framework.observe(self.charm.on.leader_elected, self._send_data)
+
+        self.framework.observe(self.charm.on[self.relation_name].relation_created, self._send_data)
+
+        if refresh_event:
+            if not isinstance(refresh_event, (tuple, list)):
+                refresh_event = [refresh_event]
+            for evt in refresh_event:
+                self.framework.observe(evt, self._send_data)
+
+    def _send_data(self, _) -> None:
+        """Serve as an event handler for sending Dex's OIDC configuration."""
+        self._provider_wrapper.send_data(self._issuer_url)
+
+
+class DexOidcConfigProviderWrapper(Object):
+    """Wrapper for the relation data sending logic.
+
+    Args:
+        charm (CharmBase): the provider application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the provider application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, charm: CharmBase, relation_name: Optional[str] = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def send_data(
+        self,
+        issuer_url: str,
+    ) -> None:
+        """Update the relation data bag with data from Dex's OIDC configuration.
+
+        This method will complete successfully even if there are no related applications.
+
+        Args:
+            issuer_url (str): This is the canonical URL that OIDC clients MUST use to refer to dex.
+        """
+        # Validate unit is leader to send data; otherwise return
+        if not self.charm.model.unit.is_leader():
+            logger.info(
+                "DexOidcConfigProvider handled send_data event when it is not the leader."
+                "Skipping event - no data sent."
+            )
+        # Update the relation data bag with Dex's OIDC configuration
+        relations = self.charm.model.relations[self.relation_name]
+
+        # Update relation data
+        for relation in relations:
+            relation.data[self.charm.app].update(
+                {
+                    "issuer-url": issuer_url,
+                }
+            )

--- a/lib/charms/dex_auth/v0/dex_oidc_config.py
+++ b/lib/charms/dex_auth/v0/dex_oidc_config.py
@@ -43,7 +43,7 @@ class DexOidcConfigRelationMissingError(DexOidcConfigRelationError):
     """Exception to raise when the relation is missing on either end."""
 
     def __init__(self):
-        self.message = "Missing relation with a k8s service info provider."
+        self.message = "Missing relation with a Dex OIDC config provider."
         super().__init__(self.message)
 
 
@@ -62,7 +62,7 @@ class DexOidcConfigUpdatedEvent(RelationEvent):
 class DexOidcConfigEvents(ObjectEvents):
     """Events for the Dex OIDC config library."""
 
-    updated = EventSource(DexOidcConfigUpdatedEvent)
+    updated = EventSource(DexOidcConfigUpdatedEventDex OIDC config)
 
 
 class DexOidcConfigObject(BaseModel):

--- a/lib/charms/harness_extensions/v0/capture_events.py
+++ b/lib/charms/harness_extensions/v0/capture_events.py
@@ -1,0 +1,85 @@
+"""This is a library providing a utility for unittesting events fired on a
+Harness-ed Charm.
+
+Example usage:
+
+>>> from charms.harness_extensions.v0.capture_events import capture
+>>> with capture(RelationEvent) as captured:
+>>>     harness.add_relation('foo', 'remote')
+>>> assert captured.event.unit.name == 'remote'
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "9fcdab70e26d4eee9797c0e542ab397a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from contextlib import contextmanager
+from typing import Generic, Iterator, Optional, Type, TypeVar
+
+from ops.charm import CharmBase
+from ops.framework import EventBase
+
+_T = TypeVar("_T", bound=EventBase)
+
+
+@contextmanager
+def capture_events(charm: CharmBase, *types: Type[EventBase]):
+    """Capture all events of type `*types` (using instance checks)."""
+    allowed_types = types or (EventBase,)
+
+    captured = []
+    _real_emit = charm.framework._emit
+
+    def _wrapped_emit(evt):
+        if isinstance(evt, allowed_types):
+            captured.append(evt)
+        return _real_emit(evt)
+
+    charm.framework._emit = _wrapped_emit  # type: ignore # noqa # ugly
+
+    yield captured
+
+    charm.framework._emit = _real_emit  # type: ignore # noqa # ugly
+
+
+class Captured(Generic[_T]):
+    """Object to type and expose return value of capture()."""
+
+    _event = None
+
+    @property
+    def event(self) -> Optional[_T]:
+        """Return the captured event."""
+        return self._event
+
+    @event.setter
+    def event(self, val: _T):
+        self._event = val
+
+
+@contextmanager
+def capture(charm: CharmBase, typ_: Type[_T] = EventBase) -> Iterator[Captured[_T]]:
+    """Capture exactly 1 event of type `typ_`.
+
+    Will raise if more/less events have been fired, or if the returned event
+    does not pass an instance check.
+    """
+    result = Captured()
+    with capture_events(charm, typ_) as captured:
+        if not captured:
+            yield result
+
+    assert len(captured) <= 1, f"too many events captured: {captured}"
+    assert len(captured) >= 1, f"no event of type {typ_} emitted."
+    event = captured[0]
+    assert isinstance(event, typ_), f"expected {typ_}, not {type(event)}"
+    result.event = event

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements-unit.in
 #
+annotated-types==0.7.0
+    # via
+    #   -r requirements.txt
+    #   pydantic
 anyio==3.7.1
     # via
     #   -r requirements.txt
@@ -102,6 +106,12 @@ pkgutil-resolve-name==1.3.10
     #   jsonschema
 pluggy==1.5.0
     # via pytest
+pydantic==2.8.2
+    # via -r requirements.txt
+pydantic-core==2.20.1
+    # via
+    #   -r requirements.txt
+    #   pydantic
 pyrsistent==0.19.3
     # via
     #   -r requirements.txt
@@ -147,7 +157,10 @@ tomli==2.0.1
 typing-extensions==4.11.0
     # via
     #   -r requirements.txt
+    #   annotated-types
     #   cosl
+    #   pydantic
+    #   pydantic-core
 urllib3==2.0.4
     # via
     #   -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,8 @@ charmed-kubeflow-chisme
 jinja2
 lightkube
 ops
+# This is required by the dex-oidc-config library
+pydantic
 serialized-data-interface
 # from prometheus_k8s.v0.prometheus_scrape.py
 cosl

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements.in
 #
+annotated-types==0.7.0
+    # via pydantic
 anyio==3.7.1
     # via httpcore
 attrs==23.1.0
@@ -62,6 +64,10 @@ ordered-set==4.1.0
     # via deepdiff
 pkgutil-resolve-name==1.3.10
     # via jsonschema
+pydantic==2.8.2
+    # via -r requirements.in
+pydantic-core==2.20.1
+    # via pydantic
 pyrsistent==0.19.3
     # via jsonschema
 pyyaml==6.0.1
@@ -88,7 +94,11 @@ sniffio==1.3.0
 tenacity==8.2.2
     # via charmed-kubeflow-chisme
 typing-extensions==4.11.0
-    # via cosl
+    # via
+    #   annotated-types
+    #   cosl
+    #   pydantic
+    #   pydantic-core
 urllib3==2.0.4
     # via requests
 websocket-client==1.6.1

--- a/tests/unit/test_dex_oidc_config.py
+++ b/tests/unit/test_dex_oidc_config.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+from charms.dex_auth.v0.dex_oidc_config import (
+    DexOidcConfigObject,
+    DexOidcConfigProvider,
+    DexOidcConfigProviderWrapper,
+    DexOidcConfigRelationDataMissingError,
+    DexOidcConfigRelationMissingError,
+    DexOidcConfigRequirer,
+    DexOidcConfigRequirerWrapper,
+    DexOidcConfigUpdatedEvent,
+)
+from charms.harness_extensions.v0.capture_events import capture
+from ops.charm import CharmBase
+from ops.model import TooManyRelatedAppsError
+from ops.testing import Harness
+
+TEST_RELATION_NAME = "test-relation"
+REQUIRER_CHARM_META = f"""
+name: requirer-test-charm
+requires:
+  {TEST_RELATION_NAME}:
+    interface: test-interface
+"""
+PROVIDER_CHARM_META = f"""
+name: provider-test-charm
+provides:
+  {TEST_RELATION_NAME}:
+    interface: test-interface
+"""
+
+
+class GenericCharm(CharmBase):
+    pass
+
+
+@pytest.fixture()
+def requirer_charm_harness():
+    return Harness(GenericCharm, meta=REQUIRER_CHARM_META)
+
+
+@pytest.fixture()
+def provider_charm_harness():
+    return Harness(GenericCharm, meta=PROVIDER_CHARM_META)
+
+
+def test_requirer_get_data_from_requirer(requirer_charm_harness):
+    """Assert the relation data is as expected."""
+    # Initial configuration
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.set_leader(True)
+    requirer_charm_harness.begin()
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    # Add and update relation
+    expected_data = DexOidcConfigObject(issuer_url="http://my-dex.io/dex")
+    data_dict = {"issuer-url": expected_data.issuer_url}
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
+
+    # Get the relation data
+    actual_relation_data = requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
+
+    # Assert returns dictionary with expected values
+    assert actual_relation_data == expected_data
+
+
+def test_get_dex_oidc_config_on_refresh_event(requirer_charm_harness):
+    """Test the Provider correctly handles the event set in refresh_event."""
+    # Initial configuration
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.set_leader(True)
+    requirer_charm_harness.begin()
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirer(
+        requirer_charm_harness.charm,
+        relation_name=TEST_RELATION_NAME,
+        refresh_event=requirer_charm_harness.charm.on[TEST_RELATION_NAME].relation_joined,
+    )
+
+    # Add and update relation
+    expected_data = DexOidcConfigObject(issuer_url="http://my-dex.io/dex")
+    data_dict = {"issuer_url": expected_data.issuer_url}
+    rel_id = requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
+    relation = requirer_charm_harness.charm.framework.model.get_relation(
+        TEST_RELATION_NAME, rel_id
+    )
+
+    # Assert that we emit an event for data being updated
+    with capture(requirer_charm_harness, DexOidcConfigUpdatedEvent):
+        requirer_charm_harness.charm.on[TEST_RELATION_NAME].relation_joined.emit(relation)
+
+
+def test_check_raise_too_many_relations(requirer_charm_harness):
+    """Assert that TooManyRelatedAppsError is raised if more than one application is related."""
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirerWrapper(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app2")
+
+    with pytest.raises(TooManyRelatedAppsError):
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
+
+
+def test_validate_relation_raise_no_relation(requirer_charm_harness):
+    """Assert that DexOidcConfigRelationMissingError is raised in the absence of the relation."""
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirerWrapper(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    with pytest.raises(DexOidcConfigRelationMissingError):
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
+
+
+def test_validate_relation_raise_no_relation_data(requirer_charm_harness):
+    """Assert that DexOidcConfigRelationDataMissingError is raised in the absence of relation data."""  # noqa
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirerWrapper(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    with pytest.raises(DexOidcConfigRelationDataMissingError) as error:
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
+    assert str(error.value) == f"No data found in relation {TEST_RELATION_NAME} data bag."
+
+
+def test_provider_sends_data_automatically_passes(provider_charm_harness):
+    """Assert the relation data is passed automatically by the provider."""
+    provider_charm_harness.set_model_name("test-model")
+    provider_charm_harness.set_leader(True)
+    provider_charm_harness.begin()
+
+    # Instantiate the DexOidcConfigProvider
+    issuer_url = "http://my-dex.io/dex"
+    provider_charm_harness.charm._k8s_svc_info_provider = DexOidcConfigProvider(
+        charm=provider_charm_harness.charm,
+        issuer_url=issuer_url,
+        relation_name=TEST_RELATION_NAME,
+    )
+
+    # Add corresponding relation
+    provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    # Check the relation data
+    relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]
+    for relation in relations:
+        actual_relation_data = relation.data[provider_charm_harness.charm.app]
+        # Assert returns dictionary with expected values
+        assert actual_relation_data.get("issuer-url") == issuer_url
+
+
+def test_requirer_wrapper_get_data_passes(requirer_charm_harness):
+    """Assert the relation data is as expected."""
+    # Initial configuration
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.set_leader(True)
+    requirer_charm_harness.begin()
+
+    # Add and update relation
+    data_dict = {"issuer-url": "http://my-dex.io/dex"}
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirerWrapper(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    # Get the relation data
+    expected_data = DexOidcConfigObject(issuer_url=data_dict["issuer-url"])
+    actual_relation_data = requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
+
+    # Assert returns dictionary with expected values
+    assert actual_relation_data == expected_data
+
+
+def test_provider_wrapper_send_data_passes(provider_charm_harness):
+    """Assert the relation data is as expected by the provider wrapper."""
+    # Initial configuration
+    provider_charm_harness.set_model_name("test-model")
+    provider_charm_harness.begin()
+    provider_charm_harness.set_leader(True)
+    provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    # Instantiate DexOidcConfigProviderWrapper class
+    provider_charm_harness.charm._k8s_svc_info_provider = DexOidcConfigProviderWrapper(
+        provider_charm_harness.charm,
+        relation_name=TEST_RELATION_NAME,
+    )
+
+    # Send relation data
+    relation_data = DexOidcConfigObject(issuer_url="http://my-dex.io/dex")
+    provider_charm_harness.charm._k8s_svc_info_provider.send_data(
+        issuer_url=relation_data.issuer_url
+    )
+    relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]
+    for relation in relations:
+        actual_relation_data = relation.data[provider_charm_harness.charm.app]
+        # Assert returns dictionary with expected values
+        assert actual_relation_data.get("issuer-url") == relation_data.issuer_url

--- a/tests/unit/test_dex_oidc_config.py
+++ b/tests/unit/test_dex_oidc_config.py
@@ -55,7 +55,7 @@ def test_requirer_get_data_from_requirer(requirer_charm_harness):
     requirer_charm_harness.begin()
 
     # Instantiate DexOidcConfigRequirerWrapper class
-    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirer(
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirer(
         requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
     )
 
@@ -65,24 +65,24 @@ def test_requirer_get_data_from_requirer(requirer_charm_harness):
     requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
 
     # Get the relation data
-    actual_relation_data = requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
+    actual_relation_data = requirer_charm_harness.charm._dex_oidc_config_requirer.get_data()
 
     # Assert returns dictionary with expected values
     assert actual_relation_data == expected_data
 
 
-def test_get_dex_oidc_config_on_refresh_event(requirer_charm_harness):
-    """Test the Provider correctly handles the event set in refresh_event."""
+def test_get_dex_oidc_config_on_refresh_events(requirer_charm_harness):
+    """Test the Provider correctly handles the event set in refresh_events."""
     # Initial configuration
     requirer_charm_harness.set_model_name("test-model")
     requirer_charm_harness.set_leader(True)
     requirer_charm_harness.begin()
 
     # Instantiate DexOidcConfigRequirerWrapper class
-    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirer(
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirer(
         requirer_charm_harness.charm,
         relation_name=TEST_RELATION_NAME,
-        refresh_event=requirer_charm_harness.charm.on[TEST_RELATION_NAME].relation_joined,
+        refresh_events=[requirer_charm_harness.charm.on[TEST_RELATION_NAME].relation_joined],
     )
 
     # Add and update relation
@@ -105,7 +105,7 @@ def test_check_raise_too_many_relations(requirer_charm_harness):
     requirer_charm_harness.set_leader(True)
 
     # Instantiate DexOidcConfigRequirerWrapper class
-    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirerWrapper(
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirerWrapper(
         requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
     )
 
@@ -113,7 +113,7 @@ def test_check_raise_too_many_relations(requirer_charm_harness):
     requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app2")
 
     with pytest.raises(TooManyRelatedAppsError):
-        requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
+        requirer_charm_harness.charm._dex_oidc_config_requirer.get_data()
 
 
 def test_validate_relation_raise_no_relation(requirer_charm_harness):
@@ -123,12 +123,12 @@ def test_validate_relation_raise_no_relation(requirer_charm_harness):
     requirer_charm_harness.set_leader(True)
 
     # Instantiate DexOidcConfigRequirerWrapper class
-    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirerWrapper(
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirerWrapper(
         requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
     )
 
     with pytest.raises(DexOidcConfigRelationMissingError):
-        requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
+        requirer_charm_harness.charm._dex_oidc_config_requirer.get_data()
 
 
 def test_validate_relation_raise_no_relation_data(requirer_charm_harness):
@@ -138,14 +138,14 @@ def test_validate_relation_raise_no_relation_data(requirer_charm_harness):
     requirer_charm_harness.set_leader(True)
 
     # Instantiate DexOidcConfigRequirerWrapper class
-    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirerWrapper(
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirerWrapper(
         requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
     )
 
     requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
 
     with pytest.raises(DexOidcConfigRelationDataMissingError) as error:
-        requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
+        requirer_charm_harness.charm._dex_oidc_config_requirer.get_data()
     assert str(error.value) == f"No data found in relation {TEST_RELATION_NAME} data bag."
 
 
@@ -157,7 +157,7 @@ def test_provider_sends_data_automatically_passes(provider_charm_harness):
 
     # Instantiate the DexOidcConfigProvider
     issuer_url = "http://my-dex.io/dex"
-    provider_charm_harness.charm._k8s_svc_info_provider = DexOidcConfigProvider(
+    provider_charm_harness.charm._dex_oidc_config_provider = DexOidcConfigProvider(
         charm=provider_charm_harness.charm,
         issuer_url=issuer_url,
         relation_name=TEST_RELATION_NAME,
@@ -186,13 +186,13 @@ def test_requirer_wrapper_get_data_passes(requirer_charm_harness):
     requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
 
     # Instantiate DexOidcConfigRequirerWrapper class
-    requirer_charm_harness.charm._k8s_svc_info_requirer = DexOidcConfigRequirerWrapper(
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirerWrapper(
         requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
     )
 
     # Get the relation data
     expected_data = DexOidcConfigObject(issuer_url=data_dict["issuer-url"])
-    actual_relation_data = requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
+    actual_relation_data = requirer_charm_harness.charm._dex_oidc_config_requirer.get_data()
 
     # Assert returns dictionary with expected values
     assert actual_relation_data == expected_data
@@ -207,14 +207,14 @@ def test_provider_wrapper_send_data_passes(provider_charm_harness):
     provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
 
     # Instantiate DexOidcConfigProviderWrapper class
-    provider_charm_harness.charm._k8s_svc_info_provider = DexOidcConfigProviderWrapper(
+    provider_charm_harness.charm._dex_oidc_config_provider = DexOidcConfigProviderWrapper(
         provider_charm_harness.charm,
         relation_name=TEST_RELATION_NAME,
     )
 
     # Send relation data
     relation_data = DexOidcConfigObject(issuer_url="http://my-dex.io/dex")
-    provider_charm_harness.charm._k8s_svc_info_provider.send_data(
+    provider_charm_harness.charm._dex_oidc_config_provider.send_data(
         issuer_url=relation_data.issuer_url
     )
     relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]


### PR DESCRIPTION
Add a library to handle the dex-oidc-config relation interface. This library allows dex-auth to share its OIDC configuration with OIDC clients such as the oidc-gatekeeper charm. The library is designed to be extended to share any information about Dex, but right now it is only sharing Dex's issuer url.

Closes #203

#### Testing instructions
1. Deploy the charm from this PR
2. Deploy the charm from https://github.com/canonical/oidc-gatekeeper-operator/pull/163
3. Wait for them to become active and idle
4. Add the relation between them (interface dex-oidc-config)
5. Verify that the requirer is actually getting data from dex-auth `juju show-unit oidc-gatekeeper`. There should be the `dex-issuer-url` value.