### PR TITLE
feat: merge KF-5526-issuer-url-dev-branch into main

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,4 +14,4 @@ parts:
     charm-python-packages: [setuptools, pip]
     # Install rustc and cargo as build packages because some charm's
     # dependencies need this to be built and installed from source.
-    build-packages: [rustc, cargo]
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]

--- a/config.yaml
+++ b/config.yaml
@@ -6,14 +6,22 @@ options:
     type: boolean
     default: true
     description: Allows dex to keep a list of passwords which can be used to login to dex
+  issuer-url:
+    type: string
+    default: ''
+    description: |
+      Format http(s)://<publicly-accessible-dns-name>/dex
+      (Also referred to as issuer or OIDC provider ) This is the canonical URL that OIDC clients
+      MUST use to refer to dex. If not specified, it defaults to dex-auth's local
+      endpoint constructed from dex-auth's Kubernetes Service DNS name, the
+      Service port and Dex's endpoint, that is http://<dex-auth-app-name>.<namespace>.svc:5556/dex.
+      The default is set by the charm code, not the configuration option.
+      This configuration must be set when using a Dex connector that will try to reach Dex from outside
+      the cluster, thus it should be a publicly accessible endpoint, for example https://my-instance.in-my-cloud.some-cloud.com/dex
   port:
     type: int
     default: 5556
     description: Listening port
-  public-url:
-    type: string
-    default: ''
-    description: Publicly-accessible endpoint for cluster
   connectors:
     type: string
     default: ''

--- a/config.yaml
+++ b/config.yaml
@@ -36,3 +36,10 @@ options:
     type: string
     default: ''
     description: Static password for logging in without an external auth service
+  public-url:
+    type: string
+    default: ''
+    description: |
+      DEPRECATED - Please leave empty or use issuer-url instead. This configuration option will be removed soon.
+      It has been preserved to avoid breaking compatibility with existing deployments.
+      Publicly-accessible endpoint for cluster

--- a/lib/charms/dex_auth/v0/dex_oidc_config.py
+++ b/lib/charms/dex_auth/v0/dex_oidc_config.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for sharing Dex's OIDC configuration with OIDC clients.
+
+This library offers a Python API for providing and requesting information about
+Dex's OIDC configuration.
+The default relation name is `dex-oidc-config` and it's recommended to use that name,
+though if changed, you must ensure to pass the correct name when instantiating the
+provider and requirer classes, as well as in `metadata.yaml`.
+
+## Getting Started
+
+### Fetching the library with charmcraft
+
+Using charmcraft you can:
+```shell
+charmcraft fetch-lib charms.dex_auth.v0.dex_oidc_config
+
+
+## Using the library as requirer
+
+### Add relation to metadata.yaml
+```yaml
+requires:
+  dex-oidc-config:
+    interface: dex-oidc-config
+    limit: 1
+```
+
+### Instantiate the DexOidcConfigRequirer class in charm.py
+
+```python
+from ops.charm import CharmBase
+from charms.dex_auth.v0.dex_oidc_config import DexOidcConfigRequirer, DexOidcConfigRelationError
+
+class RequirerCharm(CharmBase):
+    def __init__(self, *args):
+        self._dex_oidc_config_requirer = DexOidcConfigRequirer(self)
+        self.framework.observe(self.on.some_event_emitted, self.some_event_function)
+        self.framework.observe(self._dex_oidc_config_requirer.on.update, self.some_event_function)
+
+    def some_event_function():
+        # use the getter function wherever the info is needed
+        try:
+            k8s_svc_info_data = self._dex_oidc_config_requirer.get_data()
+        except DexOidcConfigRelationError as error:
+            "your error handler goes here"
+```
+
+## Using the library as provider
+
+### Add relation to metadata.yaml
+```yaml
+provides:
+  dex-oidc-config:
+    interface: dex-oidc-config
+```
+
+### Instantiate the DexOidcConfigProvider class in charm.py
+
+```python
+from ops.charm import CharmBase
+from charms.dex_auth.v0.dex_oidc_config import DexOidcConfigProvider, DexOidcConfigRelationError
+
+class ProviderCharm(CharmBase):
+    def __init__(self, *args, **kwargs):
+        ...
+        self._dex_oidc_config_provider = DexOidcConfigProvider(self)
+        self.observe(self.on.some_event, self._some_event_handler)
+
+    def _some_event_handler(self, ...):
+        # This will update the relation data bag with the issuer URL 
+        try:
+            self._dex_oidc_config_provider.send_data(issuer_url)
+        except DexOidcConfigRelationError as error:
+            "your error handler goes here"
+```
+
+Alternatively, if the provider is just broadcasting known data, it can be:
+
+```python
+from ops.charm import CharmBase
+from charms.dex_auth.v0.dex_oidc_config import DexOidcConfigProvider, DexOidcConfigRelationError
+
+class ProviderCharm(CharmBase):
+    def __init__(self, *args, **kwargs):
+        ...
+        self._dex_oidc_config_provider = DexOidcConfigProvider(self)
+```
+
+## Relation data
+
+The data shared by this library is:
+* issuer-url: the canonical URL for the issuer, OIDC cliets use this to refer to Dex
+"""
+import logging
+from typing import List, Optional, Union
+
+from ops.charm import CharmBase, RelationEvent
+from ops.framework import BoundEvent, EventSource, Object, ObjectEvents
+from ops.model import Relation
+from pydantic import BaseModel
+
+# The unique Charmhub library identifier, never change it
+LIBID = "eb5a471989b246e4977399bc8cf9ae6f"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+# Default relation and interface names. If changed, consistency must be kept
+# across the provider and requirer.
+DEFAULT_RELATION_NAME = "dex-oidc-config"
+DEFAULT_INTERFACE_NAME = "dex-oidc-config"
+REQUIRED_ATTRIBUTES = ["issuer-url"]
+
+logger = logging.getLogger(__name__)
+
+
+class DexOidcConfigRelationError(Exception):
+    """Base exception class for any relation error handled by this library."""
+
+    pass
+
+
+class DexOidcConfigRelationMissingError(DexOidcConfigRelationError):
+    """Exception to raise when the relation is missing on either end."""
+
+    def __init__(self):
+        self.message = "Missing relation with a Dex OIDC config provider."
+        super().__init__(self.message)
+
+
+class DexOidcConfigRelationDataMissingError(DexOidcConfigRelationError):
+    """Exception to raise when there is missing data in the relation data bag."""
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+class DexOidcConfigUpdatedEvent(RelationEvent):
+    """Indicates the Dex OIDC config data was updated."""
+
+
+class DexOidcConfigEvents(ObjectEvents):
+    """Events for the Dex OIDC config library."""
+
+    updated = EventSource(DexOidcConfigUpdatedEvent)
+
+
+class DexOidcConfigObject(BaseModel):
+    """Representation of a Dex OIDC config object.
+
+    Args:
+        issuer_url: This is the canonical URL that OIDC clients MUST use to refer to dex.
+    """
+
+    issuer_url: str
+
+
+class DexOidcConfigRequirer(Object):
+    """Implement the Requirer end of the Dex OIDC config relation.
+
+    This library emits:
+    * DexOidcConfigUpdatedEvent: when data received on the relation is updated.
+
+    Args:
+        charm (CharmBase): the provider application
+        refresh_events: (list, optional): list of BoundEvents that this manager should handle.
+                       Use this to update the data sent on this relation on demand.
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the requirer application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    on = DexOidcConfigEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        refresh_events: Optional[List[BoundEvent]] = None,
+        relation_name: Optional[str] = DEFAULT_RELATION_NAME,
+    ):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._requirer_wrapper = DexOidcConfigRequirerWrapper(self._charm, self._relation_name)
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_changed, self._on_relation_changed
+        )
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_broken, self._on_relation_broken
+        )
+
+        if refresh_events:
+            for evt in refresh_events:
+                self.framework.observe(evt, self._on_relation_changed)
+
+    def get_data(self) -> DexOidcConfigObject:
+        """Return a DexOidcConfigObject."""
+        return self._requirer_wrapper.get_data()
+
+    def _on_relation_changed(self, event: BoundEvent) -> None:
+        """Handle relation-changed event for this relation."""
+        self.on.updated.emit(event.relation)
+
+    def _on_relation_broken(self, event: BoundEvent) -> None:
+        """Handle relation-broken event for this relation."""
+        self.on.updated.emit(event.relation)
+
+
+class DexOidcConfigRequirerWrapper(Object):
+    """Wrapper for the relation data getting logic.
+
+    Args:
+        charm (CharmBase): the requirer application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, charm, relation_name: Optional[str] = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+
+    @staticmethod
+    def _validate_relation(relation: Optional[Relation]) -> None:
+        """Series of checks for the relation and relation data.
+
+        Args:
+            relation (optional, Relation): the relation object to run the checks on.
+              This object must always come from a call of get_relation, which
+              can either return a Relation object or None.
+
+        Raises:
+            DexOidcConfigRelationDataMissingError if data is missing or incomplete
+            DexOidcConfigRelationMissingError: if there is no related application
+        """
+        # Raise if there is no related application
+        if not relation:
+            raise DexOidcConfigRelationMissingError()
+
+        # Extract remote app information from relation
+        remote_app = relation.app
+        # Get relation data from remote app
+        relation_data = relation.data[remote_app]
+
+        # Raise if there is no data found in the relation data bag
+        if not relation_data:
+            raise DexOidcConfigRelationDataMissingError(
+                f"No data found in relation {relation.name} data bag."
+            )
+
+    def get_data(self) -> DexOidcConfigObject:
+        """Return a DexOidcConfigObject containing Dex's OIDC configuration.
+
+        Raises:
+            DexOidcConfigRelationDataMissingError: if data is missing entirely or some attributes
+            DexOidcConfigRelationMissingError: if there is no related application
+            ops.model.TooManyRelatedAppsError: if there is more than one related application
+        """
+        # Validate relation data
+        # Raises TooManyRelatedAppsError if related to more than one app
+        relation = self.model.get_relation(self.relation_name)
+
+        self._validate_relation(relation=relation)
+
+        # Get relation data from remote app
+        relation_data = relation.data[relation.app]
+
+        return DexOidcConfigObject(issuer_url=relation_data["issuer-url"])
+
+
+class DexOidcConfigProvider(Object):
+    """Implement the Provider end of the Dex OIDC config relation.
+
+    Observes relation events to send data to related applications.
+
+    Args:
+        charm (CharmBase): the provider application
+        issuer_url (str): This is the canonical URL that OIDC clients MUST use to refer to dex.
+        refresh_events: (list, optional): list of BoundEvents that this manager should handle.  Use this to update
+                       the data sent on this relation on demand.
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the provider application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        issuer_url: str,
+        refresh_events: Optional[List[BoundEvent]] = None,
+        relation_name: Optional[str] = DEFAULT_RELATION_NAME,
+    ):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self._provider_wrapper = DexOidcConfigProviderWrapper(self.charm, self.relation_name)
+        self._issuer_url = issuer_url
+
+        self.framework.observe(self.charm.on.leader_elected, self._send_data)
+
+        self.framework.observe(self.charm.on[self.relation_name].relation_created, self._send_data)
+
+        if refresh_events:
+            for evt in refresh_events:
+                self.framework.observe(evt, self._send_data)
+
+    def _send_data(self, _) -> None:
+        """Serve as an event handler for sending Dex's OIDC configuration."""
+        self._provider_wrapper.send_data(self._issuer_url)
+
+
+class DexOidcConfigProviderWrapper(Object):
+    """Wrapper for the relation data sending logic.
+
+    Args:
+        charm (CharmBase): the provider application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the provider application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, charm: CharmBase, relation_name: Optional[str] = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def send_data(
+        self,
+        issuer_url: str,
+    ) -> None:
+        """Update the relation data bag with data from Dex's OIDC configuration.
+
+        This method will complete successfully even if there are no related applications.
+
+        Args:
+            issuer_url (str): This is the canonical URL that OIDC clients MUST use to refer to dex.
+        """
+        # Validate unit is leader to send data; otherwise return
+        if not self.charm.model.unit.is_leader():
+            logger.info(
+                "DexOidcConfigProvider handled send_data event when it is not the leader."
+                "Skipping event - no data sent."
+            )
+            return
+
+        # Update the relation data bag with Dex's OIDC configuration
+        relations = self.charm.model.relations[self.relation_name]
+
+        # Update relation data
+        for relation in relations:
+            relation.data[self.charm.app].update(
+                {
+                    "issuer-url": issuer_url,
+                }
+            )

--- a/lib/charms/harness_extensions/v0/capture_events.py
+++ b/lib/charms/harness_extensions/v0/capture_events.py
@@ -1,0 +1,85 @@
+"""This is a library providing a utility for unittesting events fired on a
+Harness-ed Charm.
+
+Example usage:
+
+>>> from charms.harness_extensions.v0.capture_events import capture
+>>> with capture(RelationEvent) as captured:
+>>>     harness.add_relation('foo', 'remote')
+>>> assert captured.event.unit.name == 'remote'
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "9fcdab70e26d4eee9797c0e542ab397a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from contextlib import contextmanager
+from typing import Generic, Iterator, Optional, Type, TypeVar
+
+from ops.charm import CharmBase
+from ops.framework import EventBase
+
+_T = TypeVar("_T", bound=EventBase)
+
+
+@contextmanager
+def capture_events(charm: CharmBase, *types: Type[EventBase]):
+    """Capture all events of type `*types` (using instance checks)."""
+    allowed_types = types or (EventBase,)
+
+    captured = []
+    _real_emit = charm.framework._emit
+
+    def _wrapped_emit(evt):
+        if isinstance(evt, allowed_types):
+            captured.append(evt)
+        return _real_emit(evt)
+
+    charm.framework._emit = _wrapped_emit  # type: ignore # noqa # ugly
+
+    yield captured
+
+    charm.framework._emit = _real_emit  # type: ignore # noqa # ugly
+
+
+class Captured(Generic[_T]):
+    """Object to type and expose return value of capture()."""
+
+    _event = None
+
+    @property
+    def event(self) -> Optional[_T]:
+        """Return the captured event."""
+        return self._event
+
+    @event.setter
+    def event(self, val: _T):
+        self._event = val
+
+
+@contextmanager
+def capture(charm: CharmBase, typ_: Type[_T] = EventBase) -> Iterator[Captured[_T]]:
+    """Capture exactly 1 event of type `typ_`.
+
+    Will raise if more/less events have been fired, or if the returned event
+    does not pass an instance check.
+    """
+    result = Captured()
+    with capture_events(charm, typ_) as captured:
+        if not captured:
+            yield result
+
+    assert len(captured) <= 1, f"too many events captured: {captured}"
+    assert len(captured) >= 1, f"no event of type {typ_} emitted."
+    event = captured[0]
+    assert isinstance(event, typ_), f"expected {typ_}, not {type(event)}"
+    result.event = event

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -81,6 +81,8 @@ provides:
     interface: prometheus_scrape
   grafana-dashboard:
     interface: grafana_dashboard
+  dex-oidc-config:
+    interface: dex-oidc-config
 containers:
   dex:
     resource: oci-image

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements-unit.in
 #
+annotated-types==0.7.0
+    # via
+    #   -r requirements.txt
+    #   pydantic
 anyio==3.7.1
     # via
     #   -r requirements.txt
@@ -102,6 +106,12 @@ pkgutil-resolve-name==1.3.10
     #   jsonschema
 pluggy==1.5.0
     # via pytest
+pydantic==2.8.2
+    # via -r requirements.txt
+pydantic-core==2.20.1
+    # via
+    #   -r requirements.txt
+    #   pydantic
 pyrsistent==0.19.3
     # via
     #   -r requirements.txt
@@ -147,7 +157,10 @@ tomli==2.0.1
 typing-extensions==4.11.0
     # via
     #   -r requirements.txt
+    #   annotated-types
     #   cosl
+    #   pydantic
+    #   pydantic-core
 urllib3==2.0.4
     # via
     #   -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,8 @@ charmed-kubeflow-chisme
 jinja2
 lightkube
 ops
+# This is required by the dex-oidc-config library
+pydantic
 serialized-data-interface
 # from prometheus_k8s.v0.prometheus_scrape.py
 cosl

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements.in
 #
+annotated-types==0.7.0
+    # via pydantic
 anyio==3.7.1
     # via httpcore
 attrs==23.1.0
@@ -62,6 +64,10 @@ ordered-set==4.1.0
     # via deepdiff
 pkgutil-resolve-name==1.3.10
     # via jsonschema
+pydantic==2.8.2
+    # via -r requirements.in
+pydantic-core==2.20.1
+    # via pydantic
 pyrsistent==0.19.3
     # via jsonschema
 pyyaml==6.0.1
@@ -88,7 +94,11 @@ sniffio==1.3.0
 tenacity==8.2.2
     # via charmed-kubeflow-chisme
 typing-extensions==4.11.0
-    # via cosl
+    # via
+    #   annotated-types
+    #   cosl
+    #   pydantic
+    #   pydantic-core
 urllib3==2.0.4
     # via requests
 websocket-client==1.6.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -104,6 +104,19 @@ class Operator(CharmBase):
         """Return issuer-url value if config option exists; otherwise default Dex's endpoint."""
         if issuer_url := self.model.config["issuer-url"]:
             return issuer_url
+        # TODO: remove this after the release of dex-auth 2.39
+        # This should not be supported anymore, but has been kept for compatibility
+        if public_url := self.model.config["public-url"]:
+            self.logger.warning(
+                "DEPRECATED: The public-url config option is deprecated"
+                "Please leave empty or use issuer-url;"
+                "otherwise this may cause unexpected behaviour."
+            )
+            # This will just cover cases like when the URL is my-dex.io:5557,
+            # not when it starts with a different protocol
+            if not public_url.startswith(("http://", "https://")):
+                public_url = f"http://{public_url}"
+            return f"{public_url}/dex"
         return (
             f"http://{self.model.app.name}.{self._namespace}.svc:{self.model.config['port']}/dex"
         )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -155,16 +155,13 @@ async def test_relations(ops_test: OpsTest):
     await ops_test.model.add_relation(KUBEFLOW_PROFILES, KUBEFLOW_DASHBOARD)
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{KUBEFLOW_DASHBOARD}:ingress")
 
-    # Set public-url for dex and oidc
-    # Note: This could be affected by a race condition (if service has not received
-    # an IP yet, this could fail) but probably this won't happen in practice
-    # because that IP is delivered quickly and we wait_for_idle on the istio_gateway
-    public_url = get_public_url(
-        service_name="istio-ingressgateway-workload",
-        namespace=ops_test.model_name,
-    )
-    log.info(f"got public_url of {public_url}")
-    await ops_test.model.applications[DEX_AUTH_APP_NAME].set_config({"public-url": public_url})
+    # Set public-url for oidc
+    # Leaving the default value of Dex's Kubernetes Service temporarily
+    # FIXME: remove this configuration option after canonical/oidc-gatekeeper-operator/pull/164 and
+    # canonical/oidc-gatekeeper-operator/pull/163 get merged
+    # After that, we should integrate dex-auth and oidc-gatekeeper.
+    # See canonical/oidc-gatekeeper-operator#157 for more details
+    public_url = f"http://{DEX_AUTH_APP_NAME}.{ops_test.model_name}.svc:5556"
     await ops_test.model.applications[OIDC_GATEKEEPER].set_config({"public-url": public_url})
 
     await ops_test.model.wait_for_idle(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,6 +11,8 @@ from ops.testing import Harness
 
 from charm import Operator
 
+DEX_OIDC_CONFIG_RELATION = "dex-oidc-config"
+
 
 @pytest.fixture
 def harness():
@@ -69,7 +71,6 @@ def test_generate_dex_auth_config_raises(harness):
     config_updates = {
         "enable-password-db": False,
         "port": 5555,
-        "public-url": "dummy.url",
     }
 
     harness.update_config(config_updates)
@@ -89,13 +90,11 @@ def test_generate_dex_auth_config_raises(harness):
         {
             "enable-password-db": False,
             "port": 5555,
-            "public-url": "dummy.url",
             "connectors": "test-connector",
         },
         {
             "enable-password-db": True,
             "port": 5555,
-            "public-url": "dummy.url",
             "static-username": "new-user",
             "static-password": "new-pass",
         },
@@ -141,7 +140,6 @@ def test_disable_static_login_no_connector_blocked_status(harness):
     config_updates = {
         "enable-password-db": False,
         "port": 5555,
-        "public-url": "dummy.url",
     }
 
     harness.update_config(config_updates)
@@ -156,8 +154,8 @@ def test_config_changed(update, harness):
 
     config_updates = {
         "enable-password-db": False,
+        "issuer-url": "http://my-dex.io/dex",
         "port": 5555,
-        "public-url": "dummy.url",
         "connectors": "connector01",
         "static-username": "new-user",
         "static-password": "new-pass",
@@ -219,3 +217,47 @@ def test_main_ingress(update, harness):
     }
 
     assert data == yaml.safe_load(relation_data["data"])
+
+
+@patch("charm.KubernetesServicePatch", lambda *_, **__: None)
+def test_dex_oidc_config_with_data(harness):
+    """Test the relation data has values by default as the charm is broadcasting them."""
+    harness.set_leader(True)
+    harness.begin()
+
+    rel_id = harness.add_relation(DEX_OIDC_CONFIG_RELATION, "app")
+    rel_data = harness.model.get_relation(DEX_OIDC_CONFIG_RELATION, rel_id).data[harness.model.app]
+
+    # Default values are expected
+    expected = {"issuer-url": f"http://{harness.model.app.name}.{harness.model.name}.svc:5556/dex"}
+    assert rel_data["issuer-url"] == expected["issuer-url"]
+
+
+@patch("charm.KubernetesServicePatch", lambda *_, **__: None)
+def test_grpc_relation_with_data_when_data_changes(
+    harness,
+):
+    """Test the relation data on config changed events."""
+    harness.set_leader(True)
+    # Change the configuration option before starting harness so
+    # the correct values are passed to the DexOidcConfig lib
+    # FIXME: the correct behaviour should be to change the config
+    # at any point in time to trigger config events and check the
+    # value gets passed correctly when it changes.
+    harness.update_config({"issuer-url": "http://my-dex.io/dex"})
+    harness.begin()
+
+    # Initialise a dex-oidc-config requirer charm
+    #    harness.charm.leadership_gate.get_status = MagicMock(return_value=ActiveStatus())
+    #    harness.charm.kubernetes_resources.get_status = MagicMock(return_value=ActiveStatus())
+
+    # Add relation between the requirer charm and this charm (dex-auth)
+    provider_rel_id = harness.add_relation(
+        relation_name=DEX_OIDC_CONFIG_RELATION, remote_app="other-app"
+    )
+    provider_rel_data = harness.get_relation_data(
+        relation_id=provider_rel_id, app_or_unit=harness.charm.app.name
+    )
+
+    # Change the port of the service and check the value changes
+    assert provider_rel_data["issuer-url"] == harness.model.config["issuer-url"]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -229,8 +229,8 @@ def test_dex_oidc_config_with_data(harness):
     rel_data = harness.model.get_relation(DEX_OIDC_CONFIG_RELATION, rel_id).data[harness.model.app]
 
     # Default values are expected
-    expected = {"issuer-url": f"http://{harness.model.app.name}.{harness.model.name}.svc:5556/dex"}
-    assert rel_data["issuer-url"] == expected["issuer-url"]
+    expected_url = f"http://{harness.model.app.name}.{harness.model.name}.svc:5556/dex"
+    assert rel_data["issuer-url"] == expected_url
 
 
 @patch("charm.KubernetesServicePatch", lambda *_, **__: None)

--- a/tests/unit/test_dex_oidc_config.py
+++ b/tests/unit/test_dex_oidc_config.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+from charms.dex_auth.v0.dex_oidc_config import (
+    DexOidcConfigObject,
+    DexOidcConfigProvider,
+    DexOidcConfigProviderWrapper,
+    DexOidcConfigRelationDataMissingError,
+    DexOidcConfigRelationMissingError,
+    DexOidcConfigRequirer,
+    DexOidcConfigRequirerWrapper,
+    DexOidcConfigUpdatedEvent,
+)
+from charms.harness_extensions.v0.capture_events import capture
+from ops.charm import CharmBase
+from ops.model import TooManyRelatedAppsError
+from ops.testing import Harness
+
+TEST_RELATION_NAME = "test-relation"
+REQUIRER_CHARM_META = f"""
+name: requirer-test-charm
+requires:
+  {TEST_RELATION_NAME}:
+    interface: test-interface
+"""
+PROVIDER_CHARM_META = f"""
+name: provider-test-charm
+provides:
+  {TEST_RELATION_NAME}:
+    interface: test-interface
+"""
+
+
+class GenericCharm(CharmBase):
+    pass
+
+
+@pytest.fixture()
+def requirer_charm_harness():
+    return Harness(GenericCharm, meta=REQUIRER_CHARM_META)
+
+
+@pytest.fixture()
+def provider_charm_harness():
+    return Harness(GenericCharm, meta=PROVIDER_CHARM_META)
+
+
+def test_requirer_get_data_from_requirer(requirer_charm_harness):
+    """Assert the relation data is as expected."""
+    # Initial configuration
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.set_leader(True)
+    requirer_charm_harness.begin()
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    # Add and update relation
+    expected_data = DexOidcConfigObject(issuer_url="http://my-dex.io/dex")
+    data_dict = {"issuer-url": expected_data.issuer_url}
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
+
+    # Get the relation data
+    actual_relation_data = requirer_charm_harness.charm._dex_oidc_config_requirer.get_data()
+
+    # Assert returns dictionary with expected values
+    assert actual_relation_data == expected_data
+
+
+def test_get_dex_oidc_config_on_refresh_events(requirer_charm_harness):
+    """Test the Provider correctly handles the event set in refresh_events."""
+    # Initial configuration
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.set_leader(True)
+    requirer_charm_harness.begin()
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirer(
+        requirer_charm_harness.charm,
+        relation_name=TEST_RELATION_NAME,
+        refresh_events=[requirer_charm_harness.charm.on[TEST_RELATION_NAME].relation_joined],
+    )
+
+    # Add and update relation
+    expected_data = DexOidcConfigObject(issuer_url="http://my-dex.io/dex")
+    data_dict = {"issuer_url": expected_data.issuer_url}
+    rel_id = requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
+    relation = requirer_charm_harness.charm.framework.model.get_relation(
+        TEST_RELATION_NAME, rel_id
+    )
+
+    # Assert that we emit an event for data being updated
+    with capture(requirer_charm_harness, DexOidcConfigUpdatedEvent):
+        requirer_charm_harness.charm.on[TEST_RELATION_NAME].relation_joined.emit(relation)
+
+
+def test_check_raise_too_many_relations(requirer_charm_harness):
+    """Assert that TooManyRelatedAppsError is raised if more than one application is related."""
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirerWrapper(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app2")
+
+    with pytest.raises(TooManyRelatedAppsError):
+        requirer_charm_harness.charm._dex_oidc_config_requirer.get_data()
+
+
+def test_validate_relation_raise_no_relation(requirer_charm_harness):
+    """Assert that DexOidcConfigRelationMissingError is raised in the absence of the relation."""
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirerWrapper(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    with pytest.raises(DexOidcConfigRelationMissingError):
+        requirer_charm_harness.charm._dex_oidc_config_requirer.get_data()
+
+
+def test_validate_relation_raise_no_relation_data(requirer_charm_harness):
+    """Assert that DexOidcConfigRelationDataMissingError is raised in the absence of relation data."""  # noqa
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirerWrapper(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    with pytest.raises(DexOidcConfigRelationDataMissingError) as error:
+        requirer_charm_harness.charm._dex_oidc_config_requirer.get_data()
+    assert str(error.value) == f"No data found in relation {TEST_RELATION_NAME} data bag."
+
+
+def test_provider_sends_data_automatically_passes(provider_charm_harness):
+    """Assert the relation data is passed automatically by the provider."""
+    provider_charm_harness.set_model_name("test-model")
+    provider_charm_harness.set_leader(True)
+    provider_charm_harness.begin()
+
+    # Instantiate the DexOidcConfigProvider
+    issuer_url = "http://my-dex.io/dex"
+    provider_charm_harness.charm._dex_oidc_config_provider = DexOidcConfigProvider(
+        charm=provider_charm_harness.charm,
+        issuer_url=issuer_url,
+        relation_name=TEST_RELATION_NAME,
+    )
+
+    # Add corresponding relation
+    provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    # Check the relation data
+    relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]
+    for relation in relations:
+        actual_relation_data = relation.data[provider_charm_harness.charm.app]
+        # Assert returns dictionary with expected values
+        assert actual_relation_data.get("issuer-url") == issuer_url
+
+
+def test_requirer_wrapper_get_data_passes(requirer_charm_harness):
+    """Assert the relation data is as expected."""
+    # Initial configuration
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.set_leader(True)
+    requirer_charm_harness.begin()
+
+    # Add and update relation
+    data_dict = {"issuer-url": "http://my-dex.io/dex"}
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
+
+    # Instantiate DexOidcConfigRequirerWrapper class
+    requirer_charm_harness.charm._dex_oidc_config_requirer = DexOidcConfigRequirerWrapper(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    # Get the relation data
+    expected_data = DexOidcConfigObject(issuer_url=data_dict["issuer-url"])
+    actual_relation_data = requirer_charm_harness.charm._dex_oidc_config_requirer.get_data()
+
+    # Assert returns dictionary with expected values
+    assert actual_relation_data == expected_data
+
+
+def test_provider_wrapper_send_data_passes(provider_charm_harness):
+    """Assert the relation data is as expected by the provider wrapper."""
+    # Initial configuration
+    provider_charm_harness.set_model_name("test-model")
+    provider_charm_harness.begin()
+    provider_charm_harness.set_leader(True)
+    provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    # Instantiate DexOidcConfigProviderWrapper class
+    provider_charm_harness.charm._dex_oidc_config_provider = DexOidcConfigProviderWrapper(
+        provider_charm_harness.charm,
+        relation_name=TEST_RELATION_NAME,
+    )
+
+    # Send relation data
+    relation_data = DexOidcConfigObject(issuer_url="http://my-dex.io/dex")
+    provider_charm_harness.charm._dex_oidc_config_provider.send_data(
+        issuer_url=relation_data.issuer_url
+    )
+    relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]
+    for relation in relations:
+        actual_relation_data = relation.data[provider_charm_harness.charm.app]
+        # Assert returns dictionary with expected values
+        assert actual_relation_data.get("issuer-url") == relation_data.issuer_url


### PR DESCRIPTION
This PR introduces the following changes in `main`:

* refactor: add dex-issuer-url and remove public-url config options (#209)
* feat: add dex_oidc_config library (#208)
* chore: keep public-url config option for compatibility #213 

These changes were already tested in their individual PRs. 