### PR TITLE
chore: keep public-url config option for compatibility

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,3 +36,10 @@ options:
     type: string
     default: ''
     description: Static password for logging in without an external auth service
+  public-url:
+    type: string
+    default: ''
+    description: |
+      DEPRECATED - Please leave empty or use issuer-url instead. This configuration option will be removed soon.
+      It has been preserved to avoid breaking compatibility with existing deployments.
+      Publicly-accessible endpoint for cluster

--- a/src/charm.py
+++ b/src/charm.py
@@ -104,6 +104,19 @@ class Operator(CharmBase):
         """Return issuer-url value if config option exists; otherwise default Dex's endpoint."""
         if issuer_url := self.model.config["issuer-url"]:
             return issuer_url
+        # TODO: remove this after the release of dex-auth 2.39
+        # This should not be supported anymore, but has been kept for compatibility
+        if public_url := self.model.config["public-url"]:
+            self.logger.warning(
+                "DEPRECATED: The public-url config option is deprecated"
+                "Please leave empty or use issuer-url;"
+                "otherwise this may cause unexpected behaviour."
+            )
+            # This will just cover cases like when the URL is my-dex.io:5557,
+            # not when it starts with a different protocol
+            if not public_url.startswith(("http://", "https://")):
+                public_url = f"http://{public_url}"
+            return f"{public_url}/dex"
         return (
             f"http://{self.model.app.name}.{self._namespace}.svc:{self.model.config['port']}/dex"
         )


### PR DESCRIPTION
Since this is a breaking change, it is preferrable to keep some sort of compatibility that allow users with existing deployments to keep running Dex even after the upgrade. This configuration option can be removed after a deprecation notice is rolled out.

#### Testing instructions

1. Deploy dex-auth from 2.36/stable
2. Configure `public-url` with any value `juju config dex-auth public-url="my-known-value.io"
3. Verify this value is populated in Dex's OIDC configuration:

```
curl -v <dex's svc>:5556/dex/.well-known/openid-configuration
{
  "issuer": "my-known-value.io/dex",
...
```
4. Refresh dex-auth to the charm from this PR
5. Without changing the charm configuration, make sure that Dex's OIDC configuration persists

```
curl -v <dex's svc>:5556/dex/.well-known/openid-configuration
{
  "issuer": "my-known-value.io/dex",
...
```

6. As an extra check, make sure the deprecation notice is logged `juju debug-log`