### PR TITLE
fix: add config_changed as refresh event for dex-oidc-config provider

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -41,7 +41,9 @@ class Operator(CharmBase):
         metrics_port = ServicePort(int(METRICS_PORT), name="metrics-port")
 
         # Instantiate a DexOidcConfigProvider to share this app's issuer_url
-        self.dex_oidc_config_provider = DexOidcConfigProvider(self, issuer_url=self._issuer_url)
+        self.dex_oidc_config_provider = DexOidcConfigProvider(
+            self, issuer_url=self._issuer_url, refresh_events=[self.on.config_changed]
+        )
 
         self.service_patcher = KubernetesServicePatch(
             self,


### PR DESCRIPTION
This will allow the library to handle relation data during config changed events.