### PR TITLE
feat: add Terraform module for dex-auth

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -35,6 +35,14 @@ jobs:
       - run: pip install tox
       - run: tox -e unit
 
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    with:
+      charm-path: .
+      model: kubeflow
+      channel: latest/edge
+
   integration-test:
     name: Integration
     runs-on: ubuntu-20.04

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -40,7 +40,6 @@ jobs:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
     with:
       charm-path: .
-      model: kubeflow
       channel: latest/edge
 
   integration-test:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -40,7 +40,6 @@ jobs:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
     with:
       charm-path: .
-      channel: latest/edge
 
   integration-test:
     name: Integration

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__
 *.charm
 build/
 .idea
+venv/
+.terraform*
+*.tfstate*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,9 +2,6 @@
 
 This is a Terraform module facilitating the deployment of the dex-auth charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
-## Compatibility
-This terraform module is compatible with the dex-auth charm 2.39/stable.
-
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,63 @@
+# Terraform module for dex-auth
+
+This is a Terraform module facilitating the deployment of the dex-auth charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Compatibility
+This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = dex-auth-model
+}
+
+module "dex-auth" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "dex-auth" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,7 +3,7 @@
 This is a Terraform module facilitating the deployment of the dex-auth charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 ## Compatibility
-This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
+This terraform module is compatible with the dex-auth charm 2.39/stable.
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "dex_auth" {
+  charm {
+    name     = "dex-auth"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,18 @@
+output "app_name" {
+  value = juju_application.dex_auth.name
+}
+
+output "provides" {
+  value = {
+    dex_oidc_config = "dex-oidc-config",
+    grafana_dashboard = "grafana-dashboard",
+    metrics_endpoint  = "metrics-endpoint",
+  }
+}
+
+output "requires" {
+  value = {
+    ingress = "ingress",
+    oidc_client = "oidc-client",
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,7 +4,7 @@ output "app_name" {
 
 output "provides" {
   value = {
-    dex_oidc_config = "dex-oidc-config",
+    dex_oidc_config   = "dex-oidc-config",
     grafana_dashboard = "grafana-dashboard",
     metrics_endpoint  = "metrics-endpoint",
   }
@@ -12,7 +12,7 @@ output "provides" {
 
 output "requires" {
   value = {
-    ingress = "ingress",
+    ingress     = "ingress",
     oidc_client = "oidc-client",
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -13,6 +13,7 @@ output "provides" {
 output "requires" {
   value = {
     ingress     = "ingress",
+    logging     = "logging",
     oidc_client = "oidc-client",
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "dex-auth"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -79,3 +79,10 @@ commands = pytest -vvs --tb native --log-cli-level=INFO --asyncio-mode=auto {tox
 deps =
     -r requirements-integration.txt
 description = Run integration tests
+
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards


### PR DESCRIPTION
This commit adds the terraform/ directory to the root of the repository to host the Terraform module of this charm. This follows the standard set in CC006. For more information please also refer to canonical/argo-operators/pull/198.

Part of #226


#### Testing instructions

1. Check the correctness of the module with `tox -e tflint`
2. Apply with `terraform apply -var "channel=latest/edge" -var "model_name=kubeflow" --auto-approve`
3. Wait for the charm to be deployed.

#### For reviewers

This module must expose all the information in the `metadata.yaml` of this charm, make sure you review it by comparing that file to the Tf files in this PR.