### PR TITLE
dex expiry settings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,3 +43,13 @@ options:
       DEPRECATED - Please leave empty or use issuer-url instead. This configuration option will be removed soon.
       It has been preserved to avoid breaking compatibility with existing deployments.
       Publicly-accessible endpoint for cluster
+  enable-expiry:
+    type: boolean
+    default: false
+    description: Modify expiry settings for dex
+  expiry-settings:
+    type: string
+    default: ''
+    description: |
+      Expiry settings in YAML format, as shown
+      in https://dexidp.io/docs/configuration/tokens/#expiration-and-rotation-settings

--- a/src/charm.py
+++ b/src/charm.py
@@ -226,6 +226,8 @@ class Operator(CharmBase):
             "staticPasswords": [],
         }
 
+        enable_expiry = self.model.config["enable-expiry"]
+
         # The dex-auth service cannot be started correctly when the static
         # login is disabled, but no connector configuration is provided.
         if not enable_password_db and not connectors:
@@ -249,6 +251,12 @@ class Operator(CharmBase):
                     }
                 ],
             }
+
+        # Add expiry settings for dex-auth
+        # This operation might modify the security level
+        if enable_expiry:
+            expiry_config = yaml.safe_load(self.model.config["expiry-settings"])
+            static_config["expiry"] = expiry_config
 
         config = yaml.dump(
             {


### PR DESCRIPTION
Support for expiry settings for dex-auth-operator

Below is the example code to set expiry, 

```bash
juju config dex-auth enable-expiry=true

cat <<EOF > expiry.json
{
"idTokens": "240h",
"deviceRequests": "5m",
"signingKeys": "6h",
"refreshTokens": {
"disableRotation": false,
"reuseInterval": "3s",
"validIfNotUsedFor": "2160h", # 90 days
"absoluteLifetime": "3960h", # 165 days
}
}
EOF
EXP_JSON=$(cat expiry.json)

juju config dex-auth expiry-settings="$EXP_JSON"
```