### PR TITLE
chore: bump dexidp image 2.39 -> 2.41

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -90,4 +90,4 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for dex container
-    upstream-source: charmedkubeflow/dex:2.39.1-a91817e
+    upstream-source: ghcr.io/dexidp/dex:v2.41.1


### PR DESCRIPTION
Bump the container image 2.39 -> 2.41 in preparation for a new release.