### PR TITLE
feat: Add ingress requirer implementation and oauth provider implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 venv/
 .terraform*
 *.tfstate*
+.vscode/

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,9 +9,16 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
+charm-libs:
+  - lib: traefik_k8s.ingress
+    version: "2"
+  - lib: hydra.oauth
+    version: "0"
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
     # Install rustc and cargo as build packages because some charm's
     # dependencies need this to be built and installed from source.
     build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]
+assumes:
+  - juju >= 3.3

--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -1,0 +1,807 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""# Oauth Library.
+
+This library is designed to enable applications to register OAuth2/OIDC
+clients with an OIDC Provider through the `oauth` interface.
+
+## Getting started
+
+To get started using this library you just need to fetch the library using `charmcraft`. **Note
+that you also need to add `jsonschema` to your charm's `requirements.txt`.**
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.hydra.v0.oauth
+EOF
+```
+
+Then, to initialize the library:
+```python
+# ...
+from charms.hydra.v0.oauth import ClientConfig, OAuthRequirer
+
+OAUTH = "oauth"
+OAUTH_SCOPES = "openid email"
+OAUTH_GRANT_TYPES = ["authorization_code"]
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.oauth = OAuthRequirer(self, client_config, relation_name=OAUTH)
+
+    self.framework.observe(self.oauth.on.oauth_info_changed, self._configure_application)
+    # ...
+
+    def _on_ingress_ready(self, event):
+        self.external_url = "https://example.com"
+        self._set_client_config()
+
+    def _set_client_config(self):
+        client_config = ClientConfig(
+            urljoin(self.external_url, "/oauth/callback"),
+            OAUTH_SCOPES,
+            OAUTH_GRANT_TYPES,
+        )
+        self.oauth.update_client_config(client_config)
+```
+"""
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field, fields
+from typing import Dict, List, Mapping, Optional
+
+import jsonschema
+from ops.charm import CharmBase, RelationBrokenEvent, RelationChangedEvent, RelationCreatedEvent
+from ops.framework import EventBase, EventSource, Handle, Object, ObjectEvents
+from ops.model import Relation, Secret, SecretNotFoundError, TooManyRelatedAppsError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "a3a301e325e34aac80a2d633ef61fe97"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 10
+
+PYDEPS = ["jsonschema"]
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "oauth"
+ALLOWED_GRANT_TYPES = [
+    "authorization_code",
+    "refresh_token",
+    "client_credentials",
+    "urn:ietf:params:oauth:grant-type:device_code",
+]
+ALLOWED_CLIENT_AUTHN_METHODS = ["client_secret_basic", "client_secret_post"]
+CLIENT_SECRET_FIELD = "secret"
+
+url_regex = re.compile(
+    r"(^http://)|(^https://)"  # http:// or https://
+    r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|"
+    r"[A-Z0-9-]{2,}\.?)|"  # domain...
+    r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
+    r"(?::\d+)?"  # optional port
+    r"(?:/?|[/?]\S+)$",
+    re.IGNORECASE,
+)
+
+OAUTH_PROVIDER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/oauth/schemas/provider.json",
+    "type": "object",
+    "properties": {
+        "issuer_url": {
+            "type": "string",
+        },
+        "authorization_endpoint": {
+            "type": "string",
+        },
+        "token_endpoint": {
+            "type": "string",
+        },
+        "introspection_endpoint": {
+            "type": "string",
+        },
+        "userinfo_endpoint": {
+            "type": "string",
+        },
+        "jwks_endpoint": {
+            "type": "string",
+        },
+        "scope": {
+            "type": "string",
+        },
+        "client_id": {
+            "type": "string",
+        },
+        "client_secret_id": {
+            "type": "string",
+        },
+        "groups": {"type": "string", "default": None},
+        "ca_chain": {"type": "array", "items": {"type": "string"}, "default": []},
+        "jwt_access_token": {"type": "string", "default": "False"},
+    },
+    "required": [
+        "issuer_url",
+        "authorization_endpoint",
+        "token_endpoint",
+        "introspection_endpoint",
+        "userinfo_endpoint",
+        "jwks_endpoint",
+        "scope",
+    ],
+}
+OAUTH_REQUIRER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/oauth/schemas/requirer.json",
+    "type": "object",
+    "properties": {
+        "redirect_uri": {
+            "type": "string",
+            "default": None,
+        },
+        "audience": {"type": "array", "default": [], "items": {"type": "string"}},
+        "scope": {"type": "string", "default": None},
+        "grant_types": {
+            "type": "array",
+            "default": None,
+            "items": {
+                "enum": ALLOWED_GRANT_TYPES,
+                "type": "string",
+            },
+        },
+        "token_endpoint_auth_method": {
+            "type": "string",
+            "enum": ALLOWED_CLIENT_AUTHN_METHODS,
+            "default": "client_secret_basic",
+        },
+    },
+    "required": ["redirect_uri", "audience", "scope", "grant_types", "token_endpoint_auth_method"],
+}
+
+
+class ClientConfigError(Exception):
+    """Emitted when invalid client config is provided."""
+
+
+class DataValidationError(RuntimeError):
+    """Raised when data validation fails on relation data."""
+
+
+def _load_data(data: Mapping, schema: Optional[Dict] = None) -> Dict:
+    """Parses nested fields and checks whether `data` matches `schema`."""
+    ret = {}
+    for k, v in data.items():
+        try:
+            ret[k] = json.loads(v)
+        except json.JSONDecodeError:
+            ret[k] = v
+
+    if schema:
+        _validate_data(ret, schema)
+    return ret
+
+
+def _dump_data(data: Dict, schema: Optional[Dict] = None) -> Dict:
+    if schema:
+        _validate_data(data, schema)
+
+    ret = {}
+    for k, v in data.items():
+        if isinstance(v, (list, dict)):
+            try:
+                ret[k] = json.dumps(v)
+            except json.JSONDecodeError as e:
+                raise DataValidationError(f"Failed to encode relation json: {e}")
+        elif isinstance(v, bool):
+            ret[k] = str(v)
+        else:
+            ret[k] = v
+    return ret
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    if not isinstance(val, str):
+        raise ValueError(f"invalid value type {type(val)}")
+
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val}")
+
+
+class OAuthRelation(Object):
+    """A class containing helper methods for oauth relation."""
+
+    def _pop_relation_data(self, relation_id: Relation) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        if len(self.model.relations) == 0:
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        if not relation or not relation.app:
+            return
+
+        try:
+            for data in list(relation.data[self.model.app]):
+                relation.data[self.model.app].pop(data, "")
+        except Exception as e:
+            logger.info(f"Failed to pop the relation data: {e}")
+
+
+def _validate_data(data: Dict, schema: Dict) -> None:
+    """Checks whether `data` matches `schema`.
+
+    Will raise DataValidationError if the data is not valid, else return None.
+    """
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise DataValidationError(data, schema) from e
+
+
+@dataclass
+class ClientConfig:
+    """Helper class containing a client's configuration."""
+
+    redirect_uri: str
+    scope: str
+    grant_types: List[str]
+    audience: List[str] = field(default_factory=lambda: [])
+    token_endpoint_auth_method: str = "client_secret_basic"
+    client_id: Optional[str] = None
+
+    def validate(self) -> None:
+        """Validate the client configuration."""
+        # Validate redirect_uri
+        if not re.match(url_regex, self.redirect_uri):
+            raise ClientConfigError(f"Invalid URL {self.redirect_uri}")
+
+        if self.redirect_uri.startswith("http://"):
+            logger.warning("Provided Redirect URL uses http scheme. Don't do this in production")
+
+        # Validate grant_types
+        for grant_type in self.grant_types:
+            if grant_type not in ALLOWED_GRANT_TYPES:
+                raise ClientConfigError(
+                    f"Invalid grant_type {grant_type}, must be one " f"of {ALLOWED_GRANT_TYPES}"
+                )
+
+        # Validate client authentication methods
+        if self.token_endpoint_auth_method not in ALLOWED_CLIENT_AUTHN_METHODS:
+            raise ClientConfigError(
+                f"Invalid client auth method {self.token_endpoint_auth_method}, "
+                f"must be one of {ALLOWED_CLIENT_AUTHN_METHODS}"
+            )
+
+    def to_dict(self) -> Dict:
+        """Convert object to dict."""
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+@dataclass
+class OauthProviderConfig:
+    """Helper class containing provider's configuration."""
+
+    issuer_url: str
+    authorization_endpoint: str
+    token_endpoint: str
+    introspection_endpoint: str
+    userinfo_endpoint: str
+    jwks_endpoint: str
+    scope: str
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    groups: Optional[str] = None
+    ca_chain: Optional[str] = None
+    jwt_access_token: Optional[bool] = False
+
+    @classmethod
+    def from_dict(cls, dic: Dict) -> "OauthProviderConfig":
+        """Generate OauthProviderConfig instance from dict."""
+        jwt_access_token = False
+        if "jwt_access_token" in dic:
+            jwt_access_token = strtobool(dic["jwt_access_token"])
+        return cls(
+            jwt_access_token=jwt_access_token,
+            **{
+                k: v
+                for k, v in dic.items()
+                if k in [f.name for f in fields(cls)] and k != "jwt_access_token"
+            },
+        )
+
+
+class OAuthInfoChangedEvent(EventBase):
+    """Event to notify the charm that the information in the databag changed."""
+
+    def __init__(self, handle: Handle, client_id: str, client_secret_id: str):
+        super().__init__(handle)
+        self.client_id = client_id
+        self.client_secret_id = client_secret_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "client_id": self.client_id,
+            "client_secret_id": self.client_secret_id,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        super().restore(snapshot)
+        self.client_id = snapshot["client_id"]
+        self.client_secret_id = snapshot["client_secret_id"]
+
+
+class InvalidClientConfigEvent(EventBase):
+    """Event to notify the charm that the client configuration is invalid."""
+
+    def __init__(self, handle: Handle, error: str):
+        super().__init__(handle)
+        self.error = error
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "error": self.error,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.error = snapshot["error"]
+
+
+class OAuthInfoRemovedEvent(EventBase):
+    """Event to notify the charm that the provider data was removed."""
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {}
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        pass
+
+
+class OAuthRequirerEvents(ObjectEvents):
+    """Event descriptor for events raised by `OAuthRequirerEvents`."""
+
+    oauth_info_changed = EventSource(OAuthInfoChangedEvent)
+    oauth_info_removed = EventSource(OAuthInfoRemovedEvent)
+    invalid_client_config = EventSource(InvalidClientConfigEvent)
+
+
+class OAuthRequirer(OAuthRelation):
+    """Register an oauth client."""
+
+    on = OAuthRequirerEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        client_config: Optional[ClientConfig] = None,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ) -> None:
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._client_config = client_config
+        events = self._charm.on[relation_name]
+        self.framework.observe(events.relation_created, self._on_relation_created_event)
+        self.framework.observe(events.relation_changed, self._on_relation_changed_event)
+        self.framework.observe(events.relation_broken, self._on_relation_broken_event)
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        try:
+            self._update_relation_data(self._client_config, event.relation.id)
+        except ClientConfigError as e:
+            self.on.invalid_client_config.emit(e.args[0])
+
+    def _on_relation_broken_event(self, event: RelationBrokenEvent) -> None:
+        # Workaround for https://github.com/canonical/operator/issues/888
+        self._pop_relation_data(event.relation.id)
+        if self.is_client_created():
+            event.defer()
+            logger.info("Relation data still available. Deferring the event")
+            return
+
+        # Notify the requirer that the relation data was removed
+        self.on.oauth_info_removed.emit()
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        data = event.relation.data[event.app]
+        if not data:
+            logger.info("No relation data available.")
+            return
+
+        data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+
+        client_id = data.get("client_id")
+        client_secret_id = data.get("client_secret_id")
+        if not client_id or not client_secret_id:
+            logger.info("OAuth Provider info is available, waiting for client to be registered.")
+            # The client credentials are not ready yet, so we do nothing
+            # This could mean that the client credentials were removed from the databag,
+            # but we don't allow that (for now), so we don't have to check for it.
+            return
+
+        self.on.oauth_info_changed.emit(client_id, client_secret_id)
+
+    def _update_relation_data(
+        self, client_config: Optional[ClientConfig], relation_id: Optional[int] = None
+    ) -> None:
+        if not self.model.unit.is_leader() or not client_config:
+            return
+
+        if not isinstance(client_config, ClientConfig):
+            raise ValueError(f"Unexpected client_config type: {type(client_config)}")
+
+        client_config.validate()
+
+        try:
+            relation = self.model.get_relation(
+                relation_name=self._relation_name, relation_id=relation_id
+            )
+        except TooManyRelatedAppsError:
+            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
+
+        if not relation or not relation.app:
+            return
+
+        data = _dump_data(client_config.to_dict(), OAUTH_REQUIRER_JSON_SCHEMA)
+        relation.data[self.model.app].update(data)
+
+    def is_client_created(self, relation_id: Optional[int] = None) -> bool:
+        """Check if the client has been created."""
+        if len(self.model.relations) == 0:
+            return None
+        try:
+            relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        except TooManyRelatedAppsError:
+            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
+
+        if not relation or not relation.app:
+            return None
+
+        return (
+            "client_id" in relation.data[relation.app]
+            and "client_secret_id" in relation.data[relation.app]
+        )
+
+    def get_provider_info(
+        self, relation_id: Optional[int] = None
+    ) -> Optional[OauthProviderConfig]:
+        """Get the provider information from the databag."""
+        if len(self.model.relations) == 0:
+            return None
+        try:
+            relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        except TooManyRelatedAppsError:
+            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
+        if not relation or not relation.app:
+            return None
+
+        data = relation.data[relation.app]
+        if not data:
+            logger.info("No relation data available.")
+            return
+
+        data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+
+        client_secret_id = data.get("client_secret_id")
+        if client_secret_id:
+            _client_secret = self.get_client_secret(client_secret_id)
+            client_secret = _client_secret.get_content()[CLIENT_SECRET_FIELD]
+            data["client_secret"] = client_secret
+
+        oauth_provider = OauthProviderConfig.from_dict(data)
+        return oauth_provider
+
+    def get_client_secret(self, client_secret_id: str) -> Secret:
+        """Get the client_secret."""
+        client_secret = self.model.get_secret(id=client_secret_id)
+        return client_secret
+
+    def update_client_config(
+        self, client_config: ClientConfig, relation_id: Optional[int] = None
+    ) -> None:
+        """Update the client config stored in the object."""
+        self._client_config = client_config
+        self._update_relation_data(client_config, relation_id=relation_id)
+
+
+class ClientCreatedEvent(EventBase):
+    """Event to notify the Provider charm to create a new client."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        redirect_uri: str,
+        scope: str,
+        grant_types: List[str],
+        audience: List,
+        token_endpoint_auth_method: str,
+        relation_id: int,
+    ) -> None:
+        super().__init__(handle)
+        self.redirect_uri = redirect_uri
+        self.scope = scope
+        self.grant_types = grant_types
+        self.audience = audience
+        self.token_endpoint_auth_method = token_endpoint_auth_method
+        self.relation_id = relation_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scope,
+            "grant_types": self.grant_types,
+            "audience": self.audience,
+            "token_endpoint_auth_method": self.token_endpoint_auth_method,
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.redirect_uri = snapshot["redirect_uri"]
+        self.scope = snapshot["scope"]
+        self.grant_types = snapshot["grant_types"]
+        self.audience = snapshot["audience"]
+        self.token_endpoint_auth_method = snapshot["token_endpoint_auth_method"]
+        self.relation_id = snapshot["relation_id"]
+
+    def to_client_config(self) -> ClientConfig:
+        """Convert the event information to a ClientConfig object."""
+        return ClientConfig(
+            self.redirect_uri,
+            self.scope,
+            self.grant_types,
+            self.audience,
+            self.token_endpoint_auth_method,
+        )
+
+
+class ClientChangedEvent(EventBase):
+    """Event to notify the Provider charm that the client config changed."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        redirect_uri: str,
+        scope: str,
+        grant_types: List,
+        audience: List,
+        token_endpoint_auth_method: str,
+        relation_id: int,
+        client_id: str,
+    ) -> None:
+        super().__init__(handle)
+        self.redirect_uri = redirect_uri
+        self.scope = scope
+        self.grant_types = grant_types
+        self.audience = audience
+        self.token_endpoint_auth_method = token_endpoint_auth_method
+        self.relation_id = relation_id
+        self.client_id = client_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scope,
+            "grant_types": self.grant_types,
+            "audience": self.audience,
+            "token_endpoint_auth_method": self.token_endpoint_auth_method,
+            "relation_id": self.relation_id,
+            "client_id": self.client_id,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.redirect_uri = snapshot["redirect_uri"]
+        self.scope = snapshot["scope"]
+        self.grant_types = snapshot["grant_types"]
+        self.audience = snapshot["audience"]
+        self.token_endpoint_auth_method = snapshot["token_endpoint_auth_method"]
+        self.relation_id = snapshot["relation_id"]
+        self.client_id = snapshot["client_id"]
+
+    def to_client_config(self) -> ClientConfig:
+        """Convert the event information to a ClientConfig object."""
+        return ClientConfig(
+            self.redirect_uri,
+            self.scope,
+            self.grant_types,
+            self.audience,
+            self.token_endpoint_auth_method,
+            self.client_id,
+        )
+
+
+class ClientDeletedEvent(EventBase):
+    """Event to notify the Provider charm that the client was deleted."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        relation_id: int,
+    ) -> None:
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {"relation_id": self.relation_id}
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class OAuthProviderEvents(ObjectEvents):
+    """Event descriptor for events raised by `OAuthProviderEvents`."""
+
+    client_created = EventSource(ClientCreatedEvent)
+    client_changed = EventSource(ClientChangedEvent)
+    client_deleted = EventSource(ClientDeletedEvent)
+
+
+class OAuthProvider(OAuthRelation):
+    """A provider object for OIDC Providers."""
+
+    on = OAuthProviderEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(
+            events.relation_changed,
+            self._get_client_config_from_relation_data,
+        )
+        self.framework.observe(
+            events.relation_broken,
+            self._on_relation_broken,
+        )
+
+    def _get_client_config_from_relation_data(self, event: RelationChangedEvent) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        data = event.relation.data[event.app]
+        if not data:
+            logger.info("No requirer relation data available.")
+            return
+
+        client_data = _load_data(data, OAUTH_REQUIRER_JSON_SCHEMA)
+        redirect_uri = client_data.get("redirect_uri")
+        scope = client_data.get("scope")
+        grant_types = client_data.get("grant_types")
+        audience = client_data.get("audience")
+        token_endpoint_auth_method = client_data.get("token_endpoint_auth_method")
+
+        data = event.relation.data[self._charm.app]
+        if not data:
+            logger.info("No provider relation data available.")
+            return
+        provider_data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+        client_id = provider_data.get("client_id")
+
+        relation_id = event.relation.id
+
+        if client_id:
+            # Modify an existing client
+            self.on.client_changed.emit(
+                redirect_uri,
+                scope,
+                grant_types,
+                audience,
+                token_endpoint_auth_method,
+                relation_id,
+                client_id,
+            )
+        else:
+            # Create a new client
+            self.on.client_created.emit(
+                redirect_uri, scope, grant_types, audience, token_endpoint_auth_method, relation_id
+            )
+
+    def _get_secret_label(self, relation: Relation) -> str:
+        return f"client_secret_{relation.id}"
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        # Workaround for https://github.com/canonical/operator/issues/888
+        self._pop_relation_data(event.relation.id)
+
+        self._delete_juju_secret(event.relation)
+        self.on.client_deleted.emit(event.relation.id)
+
+    def _create_juju_secret(self, client_secret: str, relation: Relation) -> Secret:
+        """Create a juju secret and grant it to a relation."""
+        secret = {CLIENT_SECRET_FIELD: client_secret}
+        juju_secret = self.model.app.add_secret(secret, label=self._get_secret_label(relation))
+        juju_secret.grant(relation)
+        return juju_secret
+
+    def _delete_juju_secret(self, relation: Relation) -> None:
+        try:
+            secret = self.model.get_secret(label=self._get_secret_label(relation))
+        except SecretNotFoundError:
+            return
+        else:
+            secret.remove_all_revisions()
+
+    def set_provider_info_in_relation_data(
+        self,
+        issuer_url: str,
+        authorization_endpoint: str,
+        token_endpoint: str,
+        introspection_endpoint: str,
+        userinfo_endpoint: str,
+        jwks_endpoint: str,
+        scope: str,
+        groups: Optional[str] = None,
+        ca_chain: Optional[str] = None,
+        jwt_access_token: Optional[bool] = False,
+    ) -> None:
+        """Put the provider information in the databag."""
+        if not self.model.unit.is_leader():
+            return
+
+        data = {
+            "issuer_url": issuer_url,
+            "authorization_endpoint": authorization_endpoint,
+            "token_endpoint": token_endpoint,
+            "introspection_endpoint": introspection_endpoint,
+            "userinfo_endpoint": userinfo_endpoint,
+            "jwks_endpoint": jwks_endpoint,
+            "scope": scope,
+            "jwt_access_token": jwt_access_token,
+        }
+        if groups:
+            data["groups"] = groups
+        if ca_chain:
+            data["ca_chain"] = ca_chain
+
+        for relation in self.model.relations[self._relation_name]:
+            relation.data[self.model.app].update(_dump_data(data))
+
+    def set_client_credentials_in_relation_data(
+        self, relation_id: int, client_id: str, client_secret: str
+    ) -> None:
+        """Put the client credentials in the databag."""
+        if not self.model.unit.is_leader():
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id)
+        if not relation or not relation.app:
+            return
+        # TODO: What if we are refreshing the client_secret? We need to add a
+        # new revision for that
+        secret = self._create_juju_secret(client_secret, relation)
+        data = {"client_id": client_id, "client_secret_id": secret.id}
+        relation.data[self.model.app].update(_dump_data(data))

--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -1,0 +1,849 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""# Interface Library for ingress.
+
+This library wraps relation endpoints using the `ingress` interface
+and provides a Python API for both requesting and providing per-application
+ingress, with load-balancing occurring across all units.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.traefik_k8s.v2.ingress
+```
+
+In the `metadata.yaml` of the charm, add the following:
+
+```yaml
+requires:
+    ingress:
+        interface: ingress
+        limit: 1
+```
+
+Then, to initialise the library:
+
+```python
+from charms.traefik_k8s.v2.ingress import (IngressPerAppRequirer,
+  IngressPerAppReadyEvent, IngressPerAppRevokedEvent)
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.ingress = IngressPerAppRequirer(self, port=80)
+    # The following event is triggered when the ingress URL to be used
+    # by this deployment of the `SomeCharm` is ready (or changes).
+    self.framework.observe(
+        self.ingress.on.ready, self._on_ingress_ready
+    )
+    self.framework.observe(
+        self.ingress.on.revoked, self._on_ingress_revoked
+    )
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        logger.info("This app's ingress URL: %s", event.url)
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
+        logger.info("This app no longer has ingress")
+"""
+import ipaddress
+import json
+import logging
+import socket
+import typing
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Callable, Dict, List, MutableMapping, Optional, Sequence, Tuple, Union
+
+import pydantic
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents, StoredState
+from ops.model import ModelError, Relation, Unit
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 2
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 14
+
+PYDEPS = ["pydantic"]
+
+DEFAULT_RELATION_NAME = "ingress"
+RELATION_INTERFACE = "ingress"
+
+log = logging.getLogger(__name__)
+BUILTIN_JUJU_KEYS = {"ingress-address", "private-address", "egress-subnets"}
+
+PYDANTIC_IS_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+if PYDANTIC_IS_V1:
+    from pydantic import validator
+
+    input_validator = partial(validator, pre=True)
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=True)
+                return databag
+
+            for key, value in self.dict(by_alias=True, exclude_defaults=True).items():  # type: ignore
+                databag[key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict, field_validator
+
+    input_validator = partial(field_validator, mode="before")
+
+    class DatabagModel(BaseModel):
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # tolerate additional keys in databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,
+        )  # type: ignore
+        """Pydantic config."""
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=True)  # type: ignore
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+            return databag
+
+
+# todo: import these models from charm-relation-interfaces/ingress/v2 instead of redeclaring them
+class IngressUrl(BaseModel):
+    """Ingress url schema."""
+
+    url: AnyHttpUrl
+
+
+class IngressProviderAppData(DatabagModel):
+    """Ingress application databag schema."""
+
+    ingress: IngressUrl
+
+
+class ProviderSchema(BaseModel):
+    """Provider schema for Ingress."""
+
+    app: IngressProviderAppData
+
+
+class IngressRequirerAppData(DatabagModel):
+    """Ingress requirer application databag model."""
+
+    model: str = Field(description="The model the application is in.")
+    name: str = Field(description="the name of the app requesting ingress.")
+    port: int = Field(description="The port the app wishes to be exposed.")
+
+    # fields on top of vanilla 'ingress' interface:
+    strip_prefix: Optional[bool] = Field(
+        default=False,
+        description="Whether to strip the prefix from the ingress url.",
+        alias="strip-prefix",
+    )
+    redirect_https: Optional[bool] = Field(
+        default=False,
+        description="Whether to redirect http traffic to https.",
+        alias="redirect-https",
+    )
+
+    scheme: Optional[str] = Field(
+        default="http", description="What scheme to use in the generated ingress url"
+    )
+
+    @input_validator("scheme")
+    def validate_scheme(cls, scheme):  # noqa: N805  # pydantic wants 'cls' as first arg
+        """Validate scheme arg."""
+        if scheme not in {"http", "https", "h2c"}:
+            raise ValueError("invalid scheme: should be one of `http|https|h2c`")
+        return scheme
+
+    @input_validator("port")
+    def validate_port(cls, port):  # noqa: N805  # pydantic wants 'cls' as first arg
+        """Validate port."""
+        assert isinstance(port, int), type(port)
+        assert 0 < port < 65535, "port out of TCP range"
+        return port
+
+
+class IngressRequirerUnitData(DatabagModel):
+    """Ingress requirer unit databag model."""
+
+    host: str = Field(description="Hostname at which the unit is reachable.")
+    ip: Optional[str] = Field(
+        None,
+        description="IP at which the unit is reachable, "
+        "IP can only be None if the IP information can't be retrieved from juju.",
+    )
+
+    @input_validator("host")
+    def validate_host(cls, host):  # noqa: N805  # pydantic wants 'cls' as first arg
+        """Validate host."""
+        assert isinstance(host, str), type(host)
+        return host
+
+    @input_validator("ip")
+    def validate_ip(cls, ip):  # noqa: N805  # pydantic wants 'cls' as first arg
+        """Validate ip."""
+        if ip is None:
+            return None
+        if not isinstance(ip, str):
+            raise TypeError(f"got ip of type {type(ip)} instead of expected str")
+        try:
+            ipaddress.IPv4Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            pass
+        try:
+            ipaddress.IPv6Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            raise ValueError(f"{ip!r} is not a valid ip address")
+
+
+class RequirerSchema(BaseModel):
+    """Requirer schema for Ingress."""
+
+    app: IngressRequirerAppData
+    unit: IngressRequirerUnitData
+
+
+class IngressError(RuntimeError):
+    """Base class for custom errors raised by this library."""
+
+
+class NotReadyError(IngressError):
+    """Raised when a relation is not ready."""
+
+
+class DataValidationError(IngressError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class _IngressPerAppBase(Object):
+    """Base class for IngressPerUnit interface classes."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self.app = self.charm.app
+        self.unit = self.charm.unit
+
+        observe = self.framework.observe
+        rel_events = charm.on[relation_name]
+        observe(rel_events.relation_created, self._handle_relation)
+        observe(rel_events.relation_joined, self._handle_relation)
+        observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_departed, self._handle_relation)
+        observe(rel_events.relation_broken, self._handle_relation_broken)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
+
+    @property
+    def relations(self):
+        """The list of Relation instances associated with this endpoint."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def _handle_relation(self, event):
+        """Subclasses should implement this method to handle a relation update."""
+        pass
+
+    def _handle_relation_broken(self, event):
+        """Subclasses should implement this method to handle a relation breaking."""
+        pass
+
+    def _handle_upgrade_or_leader(self, event):
+        """Subclasses should implement this method to handle upgrades or leadership change."""
+        pass
+
+
+class _IPAEvent(RelationEvent):
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
+
+    @classmethod
+    def __attrs__(cls):
+        return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
+
+    def __init__(self, handle, relation, *args, **kwargs):
+        super().__init__(handle, relation)
+
+        if not len(self.__args__) == len(args):
+            raise TypeError("expected {} args, got {}".format(len(self.__args__), len(args)))
+
+        for attr, obj in zip(self.__args__, args):
+            setattr(self, attr, obj)
+        for attr, default in self.__optional_kwargs__.items():
+            obj = kwargs.get(attr, default)
+            setattr(self, attr, obj)
+
+    def snapshot(self):
+        dct = super().snapshot()
+        for attr in self.__attrs__():
+            obj = getattr(self, attr)
+            try:
+                dct[attr] = obj
+            except ValueError as e:
+                raise ValueError(
+                    "cannot automagically serialize {}: "
+                    "override this method and do it "
+                    "manually.".format(obj)
+                ) from e
+
+        return dct
+
+    def restore(self, snapshot) -> None:
+        super().restore(snapshot)
+        for attr, obj in snapshot.items():
+            setattr(self, attr, obj)
+
+
+class IngressPerAppDataProvidedEvent(_IPAEvent):
+    """Event representing that ingress data has been provided for an app."""
+
+    __args__ = ("name", "model", "hosts", "strip_prefix", "redirect_https")
+
+    if typing.TYPE_CHECKING:
+        name: Optional[str] = None
+        model: Optional[str] = None
+        # sequence of hostname, port dicts
+        hosts: Sequence["IngressRequirerUnitData"] = ()
+        strip_prefix: bool = False
+        redirect_https: bool = False
+
+
+class IngressPerAppDataRemovedEvent(RelationEvent):
+    """Event representing that ingress data has been removed for an app."""
+
+
+class IngressPerAppProviderEvents(ObjectEvents):
+    """Container for IPA Provider events."""
+
+    data_provided = EventSource(IngressPerAppDataProvidedEvent)
+    data_removed = EventSource(IngressPerAppDataRemovedEvent)
+
+
+@dataclass
+class IngressRequirerData:
+    """Data exposed by the ingress requirer to the provider."""
+
+    app: "IngressRequirerAppData"
+    units: List["IngressRequirerUnitData"]
+
+
+class IngressPerAppProvider(_IngressPerAppBase):
+    """Implementation of the provider of ingress."""
+
+    on = IngressPerAppProviderEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Constructor for IngressPerAppProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation endpoint to bind to
+                (defaults to "ingress").
+        """
+        super().__init__(charm, relation_name)
+
+    def _handle_relation(self, event):
+        # created, joined or changed: if remote side has sent the required data:
+        # notify listeners.
+        if self.is_ready(event.relation):
+            data = self.get_data(event.relation)
+            self.on.data_provided.emit(  # type: ignore
+                event.relation,
+                data.app.name,
+                data.app.model,
+                [
+                    unit.dict() if PYDANTIC_IS_V1 else unit.model_dump(mode="json")
+                    for unit in data.units
+                ],
+                data.app.strip_prefix or False,
+                data.app.redirect_https or False,
+            )
+
+    def _handle_relation_broken(self, event):
+        self.on.data_removed.emit(event.relation)  # type: ignore
+
+    def wipe_ingress_data(self, relation: Relation):
+        """Clear ingress data from relation."""
+        assert self.unit.is_leader(), "only leaders can do this"
+        try:
+            relation.data
+        except ModelError as e:
+            log.warning(
+                "error {} accessing relation data for {!r}. "
+                "Probably a ghost of a dead relation is still "
+                "lingering around.".format(e, relation.name)
+            )
+            return
+        del relation.data[self.app]["ingress"]
+
+    def _get_requirer_units_data(self, relation: Relation) -> List["IngressRequirerUnitData"]:
+        """Fetch and validate the requirer's app databag."""
+        out: List["IngressRequirerUnitData"] = []
+
+        unit: Unit
+        for unit in relation.units:
+            databag = relation.data[unit]
+            try:
+                data = IngressRequirerUnitData.load(databag)
+                out.append(data)
+            except pydantic.ValidationError:
+                log.info(f"failed to validate remote unit data for {unit}")
+                raise
+        return out
+
+    @staticmethod
+    def _get_requirer_app_data(relation: Relation) -> "IngressRequirerAppData":
+        """Fetch and validate the requirer's app databag."""
+        app = relation.app
+        if app is None:
+            raise NotReadyError(relation)
+
+        databag = relation.data[app]
+        return IngressRequirerAppData.load(databag)
+
+    def get_data(self, relation: Relation) -> IngressRequirerData:
+        """Fetch the remote (requirer) app and units' databags."""
+        try:
+            return IngressRequirerData(
+                self._get_requirer_app_data(relation), self._get_requirer_units_data(relation)
+            )
+        except (pydantic.ValidationError, DataValidationError) as e:
+            raise DataValidationError("failed to validate ingress requirer data") from e
+
+    def is_ready(self, relation: Optional[Relation] = None):
+        """The Provider is ready if the requirer has sent valid data."""
+        if not relation:
+            return any(map(self.is_ready, self.relations))
+
+        try:
+            self.get_data(relation)
+        except (DataValidationError, NotReadyError) as e:
+            log.debug("Provider not ready; validation error encountered: %s" % str(e))
+            return False
+        return True
+
+    def _published_url(self, relation: Relation) -> Optional["IngressProviderAppData"]:
+        """Fetch and validate this app databag; return the ingress url."""
+        if not self.is_ready(relation) or not self.unit.is_leader():
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # Also, only leader units can read own app databags.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return None
+
+        # fetch the provider's app databag
+        databag = relation.data[self.app]
+        if not databag.get("ingress"):
+            raise NotReadyError("This application did not `publish_url` yet.")
+
+        return IngressProviderAppData.load(databag)
+
+    def publish_url(self, relation: Relation, url: str):
+        """Publish to the app databag the ingress url."""
+        ingress_url = {"url": url}
+        IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+
+    @property
+    def proxied_endpoints(self) -> Dict[str, Dict[str, str]]:
+        """Returns the ingress settings provided to applications by this IngressPerAppProvider.
+
+        For example, when this IngressPerAppProvider has provided the
+        `http://foo.bar/my-model.my-app` URL to the my-app application, the returned dictionary
+        will be:
+
+        ```
+        {
+            "my-app": {
+                "url": "http://foo.bar/my-model.my-app"
+            }
+        }
+        ```
+        """
+        results: Dict[str, Dict[str, str]] = {}
+
+        for ingress_relation in self.relations:
+            if not ingress_relation.app:
+                log.warning(
+                    f"no app in relation {ingress_relation} when fetching proxied endpoints: skipping"
+                )
+                continue
+            try:
+                ingress_data = self._published_url(ingress_relation)
+            except NotReadyError:
+                log.warning(
+                    f"no published url found in {ingress_relation}: "
+                    f"traefik didn't publish_url yet to this relation."
+                )
+                continue
+
+            if not ingress_data:
+                log.warning(f"relation {ingress_relation} not ready yet: try again in some time.")
+                continue
+            if PYDANTIC_IS_V1:
+                results[ingress_relation.app.name] = ingress_data.ingress.dict()
+            else:
+                results[ingress_relation.app.name] = ingress_data.ingress.model_dump(mode="json")
+        return results
+
+
+class IngressPerAppReadyEvent(_IPAEvent):
+    """Event representing that ingress for an app is ready."""
+
+    __args__ = ("url",)
+    if typing.TYPE_CHECKING:
+        url: Optional[str] = None
+
+
+class IngressPerAppRevokedEvent(RelationEvent):
+    """Event representing that ingress for an app has been revoked."""
+
+
+class IngressPerAppRequirerEvents(ObjectEvents):
+    """Container for IPA Requirer events."""
+
+    ready = EventSource(IngressPerAppReadyEvent)
+    revoked = EventSource(IngressPerAppRevokedEvent)
+
+
+class IngressPerAppRequirer(_IngressPerAppBase):
+    """Implementation of the requirer of the ingress relation."""
+
+    on = IngressPerAppRequirerEvents()  # type: ignore
+
+    # used to prevent spurious urls to be sent out if the event we're currently
+    # handling is a relation-broken one.
+    _stored = StoredState()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        *,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: Optional[int] = None,
+        strip_prefix: bool = False,
+        redirect_https: bool = False,
+        # fixme: this is horrible UX.
+        #  shall we switch to manually calling provide_ingress_requirements with all args when ready?
+        scheme: Union[Callable[[], str], str] = lambda: "http",
+    ):
+        """Constructor for IngressRequirer.
+
+        The request args can be used to specify the ingress properties when the
+        instance is created. If any are set, at least `port` is required, and
+        they will be sent to the ingress provider as soon as it is available.
+        All request args must be given as keyword args.
+
+        Args:
+            charm: the charm that is instantiating the library.
+            relation_name: the name of the relation endpoint to bind to (defaults to `ingress`);
+                relation must be of interface type `ingress` and have "limit: 1")
+            host: Hostname to be used by the ingress provider to address the requiring
+                application; if unspecified, the default Kubernetes service name will be used.
+            ip: Alternative addressing method other than host to be used by the ingress provider;
+                if unspecified, binding address from juju network API will be used.
+            strip_prefix: configure Traefik to strip the path prefix.
+            redirect_https: redirect incoming requests to HTTPS.
+            scheme: callable returning the scheme to use when constructing the ingress url.
+                Or a string, if the scheme is known and stable at charm-init-time.
+
+        Request Args:
+            port: the port of the service
+        """
+        super().__init__(charm, relation_name)
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self._strip_prefix = strip_prefix
+        self._redirect_https = redirect_https
+        self._get_scheme = scheme if callable(scheme) else lambda: scheme
+
+        self._stored.set_default(current_url=None)  # type: ignore
+
+        # if instantiated with a port, and we are related, then
+        # we immediately publish our ingress data  to speed up the process.
+        if port:
+            self._auto_data = host, ip, port
+        else:
+            self._auto_data = None
+
+    def _handle_relation(self, event):
+        # created, joined or changed: if we have auto data: publish it
+        self._publish_auto_data()
+        if self.is_ready():
+            # Avoid spurious events, emit only when there is a NEW URL available
+            new_url = (
+                None
+                if isinstance(event, RelationBrokenEvent)
+                else self._get_url_from_relation_data()
+            )
+            if self._stored.current_url != new_url:  # type: ignore
+                self._stored.current_url = new_url  # type: ignore
+                self.on.ready.emit(event.relation, new_url)  # type: ignore
+
+    def _handle_relation_broken(self, event):
+        self._stored.current_url = None  # type: ignore
+        self.on.revoked.emit(event.relation)  # type: ignore
+
+    def _handle_upgrade_or_leader(self, event):
+        """On upgrade/leadership change: ensure we publish the data we have."""
+        self._publish_auto_data()
+
+    def is_ready(self):
+        """The Requirer is ready if the Provider has sent valid data."""
+        try:
+            return bool(self._get_url_from_relation_data())
+        except DataValidationError as e:
+            log.debug("Requirer not ready; validation error encountered: %s" % str(e))
+            return False
+
+    def _publish_auto_data(self):
+        if self._auto_data:
+            host, ip, port = self._auto_data
+            self.provide_ingress_requirements(host=host, ip=ip, port=port)
+
+    def provide_ingress_requirements(
+        self,
+        *,
+        scheme: Optional[str] = None,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: int,
+    ):
+        """Publishes the data that Traefik needs to provide ingress.
+
+        Args:
+            scheme: Scheme to be used; if unspecified, use the one used by __init__.
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, FQDN will be used instead
+            ip: Alternative addressing method other than host to be used by the ingress provider.
+                if unspecified, binding address from juju network API will be used.
+            port: the port of the service (required)
+        """
+        for relation in self.relations:
+            self._provide_ingress_requirements(scheme, host, ip, port, relation)
+
+    def _provide_ingress_requirements(
+        self,
+        scheme: Optional[str],
+        host: Optional[str],
+        ip: Optional[str],
+        port: int,
+        relation: Relation,
+    ):
+        if self.unit.is_leader():
+            self._publish_app_data(scheme, port, relation)
+
+        self._publish_unit_data(host, ip, relation)
+
+    def _publish_unit_data(
+        self,
+        host: Optional[str],
+        ip: Optional[str],
+        relation: Relation,
+    ):
+        if not host:
+            host = socket.getfqdn()
+
+        if ip is None:
+            network_binding = self.charm.model.get_binding(relation)
+            if (
+                network_binding is not None
+                and (bind_address := network_binding.network.bind_address) is not None
+            ):
+                ip = str(bind_address)
+            else:
+                log.error("failed to retrieve ip information from juju")
+
+        unit_databag = relation.data[self.unit]
+        try:
+            IngressRequirerUnitData(host=host, ip=ip).dump(unit_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate unit data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    def _publish_app_data(
+        self,
+        scheme: Optional[str],
+        port: int,
+        relation: Relation,
+    ):
+        # assumes leadership!
+        app_databag = relation.data[self.app]
+
+        if not scheme:
+            # If scheme was not provided, use the one given to the constructor.
+            scheme = self._get_scheme()
+
+        try:
+            IngressRequirerAppData(  # type: ignore  # pyright does not like aliases
+                model=self.model.name,
+                name=self.app.name,
+                scheme=scheme,
+                port=port,
+                strip_prefix=self._strip_prefix,  # type: ignore  # pyright does not like aliases
+                redirect_https=self._redirect_https,  # type: ignore  # pyright does not like aliases
+            ).dump(app_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate app data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    @property
+    def relation(self):
+        """The established Relation instance, or None."""
+        return self.relations[0] if self.relations else None
+
+    def _get_url_from_relation_data(self) -> Optional[str]:
+        """The full ingress URL to reach the current unit.
+
+        Returns None if the URL isn't available yet.
+        """
+        relation = self.relation
+        if not relation or not relation.app:
+            return None
+
+        # fetch the provider's app databag
+        try:
+            databag = relation.data[relation.app]
+        except ModelError as e:
+            log.debug(
+                f"Error {e} attempting to read remote app data; "
+                f"probably we are in a relation_departed hook"
+            )
+            return None
+
+        if not databag:  # not ready yet
+            return None
+
+        return str(IngressProviderAppData.load(databag).ingress.url)
+
+    @property
+    def url(self) -> Optional[str]:
+        """The full ingress URL to reach the current unit.
+
+        Returns None if the URL isn't available yet.
+        """
+        data = (
+            typing.cast(Optional[str], self._stored.current_url)  # type: ignore
+            or self._get_url_from_relation_data()
+        )
+        return data

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 name: dex-auth
+display-name: Dex
 summary: A federated OpenID Connect provider
 description: |
   Dex is an identity service that uses OpenID Connect to drive authentication for other apps.
@@ -73,6 +74,9 @@ requires:
           - prefix
     versions: [v1]
     __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
+  ingress-v2:
+    interface: ingress
+    limit: 1
   logging:
     interface: loki_push_api
     optional: true
@@ -83,6 +87,9 @@ provides:
     interface: grafana_dashboard
   dex-oidc-config:
     interface: dex-oidc-config
+  oauth:
+    interface: oauth
+    limit: 1
 containers:
   dex:
     resource: oci-image

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ pydantic
 serialized-data-interface
 # from prometheus_k8s.v0.prometheus_scrape.py
 cosl
+pydantic ==2.10.3

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,6 +3,8 @@
 # See LICENSE file for licensing details.
 
 import logging
+import secrets
+import typing
 from random import choices
 from string import ascii_letters
 from uuid import uuid4
@@ -12,19 +14,38 @@ import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from charms.dex_auth.v0.dex_oidc_config import DexOidcConfigProvider
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
+from charms.hydra.v0.oauth import (
+    ClientChangedEvent,
+    ClientCreatedEvent,
+    ClientDeletedEvent,
+    OAuthProvider,
+)
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
 from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from lightkube.models.core_v1 import ServicePort
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    SecretNotFoundError,
+    WaitingStatus,
+)
 from ops.pebble import Layer
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interface
 
 METRICS_PATH = "/metrics"
 METRICS_PORT = "5558"
+
+INGRESS_V2_INTEGRATION_NAME = "ingress-v2"
+OAUTH_INTEGRATION_NAME = "oauth"
+DEFAULT_OAUTH_SCOPES = ["openid", "email", "profile"]
+
+OAUTH_STATIC_CLIENT_SECRET_LABEL = "oauth.static.client"
 
 
 class Operator(CharmBase):
@@ -36,6 +57,9 @@ class Operator(CharmBase):
         self.logger: logging.Logger = logging.getLogger(__name__)
         self._namespace = self.model.name
 
+        self._ingress = IngressPerAppRequirer(
+            self, relation_name=INGRESS_V2_INTEGRATION_NAME, port=int(self.model.config["port"])
+        )
         # Patch the service to correctly expose the ports to be used
         dex_port = ServicePort(int(self.model.config["port"]), name="dex")
         metrics_port = ServicePort(int(METRICS_PORT), name="metrics-port")
@@ -44,6 +68,8 @@ class Operator(CharmBase):
         self.dex_oidc_config_provider = DexOidcConfigProvider(
             self, issuer_url=self._issuer_url, refresh_events=[self.on.config_changed]
         )
+
+        self._oauth_provider = OAuthProvider(self, relation_name=OAUTH_INTEGRATION_NAME)
 
         self.service_patcher = KubernetesServicePatch(
             self,
@@ -77,8 +103,21 @@ class Operator(CharmBase):
             self.on.oidc_client_relation_changed,
             self.on.ingress_relation_changed,
             self.on.dex_pebble_ready,
+            self._ingress.on.ready,
+            self._ingress.on.revoked,
+            self.on.oauth_relation_created,
         ]:
             self.framework.observe(event, self.main)
+
+        self.framework.observe(
+            self._oauth_provider.on.client_created, self._on_oauth_client_created
+        )
+        self.framework.observe(
+            self._oauth_provider.on.client_changed, self._on_oauth_client_changed
+        )
+        self.framework.observe(
+            self._oauth_provider.on.client_deleted, self._on_oauth_client_deleted
+        )
 
     @property
     def _dex_auth_layer(self) -> Layer:
@@ -120,17 +159,19 @@ class Operator(CharmBase):
             if not public_url.startswith(("http://", "https://")):
                 public_url = f"http://{public_url}"
             return f"{public_url}/dex"
+        if ingress_url := self._ingress.url:
+            return ingress_url
         return (
             f"http://{self.model.app.name}.{self._namespace}.svc:{self.model.config['port']}/dex"
         )
 
-    def _update_layer(self) -> None:
+    def _update_layer(self, dex_oauth_static_client: typing.Optional[dict]) -> None:
         """Updates the Pebble configuration layer if changed."""
         self._check_container_connection()
 
         # Generate dex-auth configuration to be passed to the pebble layer
         # so the service is (re)started.
-        dex_auth_config = self._generate_dex_auth_config()
+        dex_auth_config = self._generate_dex_auth_config(dex_oauth_static_client)
 
         # Get current layer
         current_layer = self._container.get_plan()
@@ -193,30 +234,61 @@ class Operator(CharmBase):
         return interface
 
     def main(self, event):
+        """Main reconcile loop.
+
+        Args:
+            event: Charm event
+        """
+        try:
+            secret = self.model.get_secret(label=OAUTH_STATIC_CLIENT_SECRET_LABEL)
+            oauth_client_secret = secret.get_content()
+            dex_oauth_static_client = {
+                "id": oauth_client_secret["client-id"],
+                "secret": oauth_client_secret["client-secret"],
+                "redirectURIs": [oauth_client_secret["redirect-uri"]],
+                "name": oauth_client_secret["name"],
+            }
+        except SecretNotFoundError:
+            dex_oauth_static_client = None
+
         try:
             self._check_leader()
             self.model.unit.status = MaintenanceStatus("Configuring dex charm")
             self.ensure_state()
-            self._update_layer()
+            self._update_layer(dex_oauth_static_client)
             self.handle_ingress()
         except ErrorWithStatus as err:
             self.model.unit.status = err.status
             self.logger.error(f"Failed to handle {event} with error: {err}")
             return
 
+        if self.unit.is_leader():
+            self._oauth_provider.set_provider_info_in_relation_data(
+                issuer_url=self._issuer_url,
+                authorization_endpoint=f"{self._issuer_url}/auth",
+                token_endpoint=f"{self._issuer_url}/token",
+                jwks_endpoint=f"{self._issuer_url}/keys",
+                introspection_endpoint=f"{self._issuer_url}/token/introspect",
+                userinfo_endpoint=f"{self._issuer_url}/userinfo",
+                scope=" ".join(DEFAULT_OAUTH_SCOPES),
+            )
+
         self.model.unit.status = ActiveStatus()
 
-    def _generate_dex_auth_config(self) -> str:
+    def _generate_dex_auth_config(self, dex_oauth_static_client: typing.Optional[dict]) -> str:
         """Returns dex-auth configuration to be passed when (re)starting the dex-auth service.
+
         Raises:
             CheckFailedError: when static login is disabled and no connectors are configured.
         """
         # Get OIDC client info
+        oidc_client_info = []
         oidc = self._get_interface("oidc-client")
         if oidc:
-            oidc_client_info = list(oidc.get_data().values())
-        else:
-            oidc_client_info = []
+            oidc_client_info.extend(list(oidc.get_data().values()))
+
+        if dex_oauth_static_client:
+            oidc_client_info.append(dex_oauth_static_client)
 
         # Load config values as convenient variables
         connectors = yaml.safe_load(self.model.config["connectors"])
@@ -267,6 +339,51 @@ class Operator(CharmBase):
         )
 
         return config
+
+    def _on_oauth_client_created(self, event: ClientCreatedEvent) -> None:
+        """Handle oauth-client-created event.
+
+        Args:
+            event: ClientCreatedEvent
+        """
+        if self.unit.is_leader():
+            oauth_client_static_secret = {
+                "client-id": secrets.token_hex(16),
+                "client-secret": secrets.token_hex(16),
+                "redirect-uri": event.redirect_uri,
+                "name": f"oauth_{event.relation_id}",
+            }
+
+            self.app.add_secret(
+                content=oauth_client_static_secret, label=OAUTH_STATIC_CLIENT_SECRET_LABEL
+            )
+
+            self._oauth_provider.set_client_credentials_in_relation_data(
+                event.relation_id,
+                oauth_client_static_secret["client-id"],
+                oauth_client_static_secret["client-secret"],
+            )
+            self.main(event)
+
+    def _on_oauth_client_changed(self, event: ClientChangedEvent) -> None:
+        """Handle oauth-client-changed event.
+
+        Args:
+            event: ClientChangedEvent
+        """
+        secret = self.model.get_secret(label=OAUTH_STATIC_CLIENT_SECRET_LABEL)
+
+        secret.set_content({"redirectURIs": [event.redirect_uri]})
+        self.main(event)
+
+    def _on_oauth_client_deleted(self, event: ClientDeletedEvent) -> None:
+        """Handle oauth-client-deleted event.
+
+        Args:
+            event: ClientDeletedEvent
+        """
+        self._oauth_service.remove_oauth_static_client()
+        self.main(event)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds 2 new libraries:
1. `lib/charms/hydra/v0/oauth.py` which contains the oauth provider implementation
2. `lib/charms/traefik_k8s/v2/ingress.py` which contains the ingress requirer implementation

New relations:
```
ingress-v2:
    interface: ingress
    limit: 1

oauth:
    interface: oauth
    limit: 1
```

### Ingress
The `ingress` library is used to integrate dex with provider charms like `traefik-k8s`, `nginx-ingress-integrator` and `gateway-api-integrator`, there are only 2 notable changes made in this PR:
1. The initialization of the requirer class at charm initialization
2. Update the `issuer` field of the dex config to reflect the ingress URL

### Oauth
The `oauth` provider implementation is used to integrate dex with oauth requirer charm by generating a static client, add the static client to dex's config and inform the requirer of the static client via relation data.