### PR TITLE
chore: Update CI to use 24.04

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -80,7 +80,7 @@ jobs:
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo apt install ./google-chrome-stable_current_amd64.deb
           sudo apt-get install chromium-chromedriver
-          sg snap_microk8s -c "tox -e integration -- --model kubeflow"
+          tox -e integration -- --model kubeflow
 
       - name: Get istio gateway
         run: kubectl get gateway -A

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -17,21 +17,31 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+      
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.4.0
+      with:
+        python-version: 3.8
 
     - run: pip install tox
     - run: tox -vve lint
 
   unit-test:
     name: Unit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5.4.0
+        with:
+          python-version: 3.8
+        
       - run: pip install tox
       - run: tox -e unit
 
@@ -43,11 +53,16 @@ jobs:
 
   integration-test:
     name: Integration
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5.4.0
+        with:
+          python-version: 3.8
+        
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-charm-paths:
     name: Generate the Charm Matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   publish-charm:
     name: Publish Charm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: get-charm-paths
     strategy:
       fail-fast: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,6 +83,12 @@ jobs:
           echo "setting output of tag_prefix=$tag_prefix"
           echo "::set-output name=tag_prefix::$tag_prefix"
 
+      # Required to charmcraft pack in non-destructive mode
+      - name: Setup lxd
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: latest/stable
+
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
@@ -92,3 +98,4 @@ jobs:
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
           charmcraft-channel: 3.x/stable
+          destructive-mode: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Release charm to channel


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-7137, #246 

This PR updates the CI to use `24.04`:
- We also use `setup-python` to use `3.8`
- We set `desctructive-mode` to false since we're now building on a different base that the one we are on