### PR TITLE
chore: Downgrade setup-python action to 5.3.0

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Set up Python 3.8
-      uses: actions/setup-python@v5.4.0
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: 3.8
 
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: 3.8
         
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: 3.8
         


### PR DESCRIPTION
The reason for this downgrade is that `v5.4.0` of the action doesn't actually test the setup of Python version `3.8.0`. See https://github.com/canonical/notebook-operators/pull/443#discussion_r1991435614 for more details