### PR TITLE
backport: Catch `pebble.ChangeError` when restarting the workload container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 venv/
 .terraform*
 *.tfstate*
+coverage.xml


### PR DESCRIPTION
This PR backports #280 to the `track/2.41` branch.